### PR TITLE
GitHub link http://www.wildfly.org/social/ clickable.

### DIFF
--- a/social.html.haml
+++ b/social.html.haml
@@ -33,7 +33,7 @@ description:  WildFly is the new name of JBoss Application Server.  This page in
     %p
       Get Involved!
     %p
-      %a{href=>"https://github.com/wildfly/wildfly"}https://github.com/wildfly/wildfly
+      %a{:href=>"https://github.com/wildfly/wildfly"}https://github.com/wildfly/wildfly
   .span6
     %h4
       Newsletter


### PR DESCRIPTION
Added a colon before href... 1 char fix I guess
![link](https://f.cloud.github.com/assets/691097/456482/023ed3c8-b36d-11e2-8591-68a0c99ade5c.gif)
