### PR TITLE
wildfly swarm web page - closing the tag dependency at pom.xml…

### DIFF
--- a/swarm/index.adoc
+++ b/swarm/index.adoc
@@ -22,7 +22,7 @@ dependencies to your `pom.xml`:
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>wildfly-swarm-undertow</artifactId>
-<dependency>
+</dependency>
 
 Of course, some dependencies imply others, since Maven transitively
 resolves them.
@@ -35,7 +35,7 @@ your application with the JAX-RS APIs:
 <dependency>
   <groupId>org.wildfly.swarm</groupId>
   <artifactId>wildfly-swarm-jaxrs</artifactId>
-<dependency>
+</dependency>
 ----------------------------
 
 To make your project aware of WildFly Swarm capabilities, configure


### PR DESCRIPTION
wildfly swarm web page - closing the tag dependency at pom.xml because whoever copies and paste it gets a error