### PR TITLE
Direct users to "WildFly - User" HipChat room instead of the one used…

### DIFF
--- a/gethelp.html.haml
+++ b/gethelp.html.haml
@@ -34,7 +34,7 @@ title: Get Help
             The WildFly community uses 
             %a{:href => "https://www.hipchat.com/"} HipChat
             for real-time communications. Join us in the
-            %a{:href => "https://www.hipchat.com/gW90m6pIs"} WildFly
+            %a{:href => "https://www.hipchat.com/gSW9XYz69"} WildFly
             room.
           %p
             %img(src="#{site.base_url}/images/chat.png")

--- a/news/2015-05-05-WildFly-Swarm-Released.adoc
+++ b/news/2015-05-05-WildFly-Swarm-Released.adoc
@@ -157,7 +157,7 @@ and continue doing your builds.  Everything is available through Maven Central.
 Stay in Touch
 -------------
 
-You can keep up with the project through the link:https://www.hipchat.com/gW90m6pIs[WildFly HipChat]
+You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].
 

--- a/news/2015-06-05-WildFly-Swarm-Alpha2.adoc
+++ b/news/2015-06-05-WildFly-Swarm-Alpha2.adoc
@@ -116,6 +116,6 @@ and continue doing your builds.  Everything is available through Maven Central.
 
 == Stay in Touch
 
-You can keep up with the project through the link:https://www.hipchat.com/gW90m6pIs[WildFly HipChat]
+You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].

--- a/news/2015-06-18-WildFly-Swarm-Alpha3-Released.adoc
+++ b/news/2015-06-18-WildFly-Swarm-Alpha3-Released.adoc
@@ -51,6 +51,6 @@ impatient.
 
 == Stay in Touch
 
-You can keep up with the project through the link:https://www.hipchat.com/gW90m6pIs[WildFly HipChat]
+You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].

--- a/news/2015-08-19-WildFly-Swarm-Alpha4-Released.adoc
+++ b/news/2015-08-19-WildFly-Swarm-Alpha4-Released.adoc
@@ -90,6 +90,6 @@ and continue doing your builds.
 
 == Stay in Touch
 
-You can keep up with the project through the link:https://www.hipchat.com/gW90m6pIs[WildFly HipChat]
+You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].

--- a/swarm/index.adoc
+++ b/swarm/index.adoc
@@ -138,6 +138,6 @@ Simply `java -jar ./target/myapp-swarm-jar` and it'll run.
 Community
 ----------
 
-You can keep up with the project through the link:https://www.hipchat.com/gW90m6pIs[WildFly HipChat]
+You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].


### PR DESCRIPTION
… for development discussion


[17:22] James R Perkins: There is also a WildFly User room too at https://www.hipchat.com/gSW9XYz69
		It hasn't been as active, but it could be because no one knows about it :)
[17:43] Radoslav Husar: @jperkins probably a better way - more intuitive to community - would be to leave this one (WildFly) to community and move dev to something else (e.g. WildFly Development)
[17:44] Brian Stansberry: yeah, I agree
[17:45] James R Perkins: @RadoslavHusar At this point you're probably right. Though I'm not sure who makes that call. Probably @JasonGreene :)