### PR TITLE
Add .htaccess redirects for wildfly-swarm.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+Redirect 301 /swarm http://wildfly-swarm.io/

--- a/swarm/.htaccess
+++ b/swarm/.htaccess
@@ -1,0 +1,1 @@
+Redirect 301 /swarm http://wildfly-swarm.io/


### PR DESCRIPTION
The wildfly-swarm project now has its own domain at http://wildfly-swarm.io. I'm not sure how the wildfly.org site is served, but it appears to be Apache server. Hopefully the .htaccess files here will suffice. 

    ~/s/wildfly.org git:master ❯❯❯ telnet wildfly.org 80
    Trying 209.132.182.26...
    Connected to wildfly.org.
    Escape character is '^]'.
    GET / HTTP/1.0
    
    HTTP/1.1 200 OK
    Date: Tue, 01 Dec 2015 20:52:11 GMT
    Server: Apache
    Last-Modified: Mon, 29 Jun 2015 18:55:56 GMT

The swarm site is still nascent and needs additional content, but that will come shortly. /cc @bobmcwhirter 