### PR TITLE
Add meta refresh and window.location.assign() to swarm pages

### DIFF
--- a/swarm/fractions.adoc
+++ b/swarm/fractions.adoc
@@ -1,6 +1,16 @@
 = Maven Plugin
 :awestruct-layout: project
 
+[pass]
+++++
+<script>
+window.location.assign('http://wildfly-swarm.io');
+</script>
+<meta http-equiv="refresh" content="0;URL='http://wildfly-swarm.io/'" />
+++++
+
+== This page is deprecated, please visit http://wildfly-swarm.io
+
 == Fractions
 
 Fractions within WildFly Swarm are roughly equivalent to

--- a/swarm/index.adoc
+++ b/swarm/index.adoc
@@ -1,6 +1,16 @@
 = WildFly Swarm
 :awestruct-layout: project
 
+[pass]
+++++
+<script>
+window.location.assign('http://wildfly-swarm.io');
+</script>
+<meta http-equiv="refresh" content="0;URL='http://wildfly-swarm.io/'" />
+++++
+
+== This page is deprecated, please visit http://wildfly-swarm.io
+
 What is WildFly Swarm?
 ----------------------
 
@@ -141,3 +151,4 @@ Community
 You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].
+

--- a/swarm/maven-plugin.adoc
+++ b/swarm/maven-plugin.adoc
@@ -1,6 +1,16 @@
 = Maven Plugin
 :awestruct-layout: project
 
+[pass]
+++++
+<script>
+window.location.assign('http://wildfly-swarm.io');
+</script>
+<meta http-equiv="refresh" content="0;URL='http://wildfly-swarm.io/'" />
+++++
+
+== This page is deprecated, please visit http://wildfly-swarm.io
+
 == The Plugin
 
 The `wildfly-swarm-maven-plugin` helps you run and package your


### PR DESCRIPTION
It appears that `<AllowOverrides>` is `false` for the wildfly.org web server configuration, so .htaccess files are not functional. Until that's possible, these changes will redirect browsers to http://wildfly-swarm.io for pages under http://wildfly.org/swarm. /cc @bobmcwhirter 