### PR TITLE
Links to Core and HipChat, drop IRC refs

### DIFF
--- a/joinus.html.haml
+++ b/joinus.html.haml
@@ -62,13 +62,15 @@ title: Join Us
             %i.icon-search
             Find Something To Work On
           %p 
-            After you are comfortable building the server, the next step is to find something that you would like to work on. Scan through
-            %a{:href=>"http://issues.jboss.org/browse/WFLY"} bug tracking system
-            and look for an issue you would like to fix. We also stick features that have not been scheduled / assigned into a special version called
+            After you are comfortable building the server, the next step is to find something that you would like to work on. Scan through our 
+            %a{:href=>"http://issues.jboss.org/browse/WFLY"} issue tracking system
+            and look for an issue you would like to fix. For the WildFly Core subproject, we use a 
+            %a{:href=>"http://issues.jboss.org/browse/WFCORE"} separate project in the issue tracker
+            , so it's a good idea to check there as well. We also stick features that have not been scheduled / assigned into a special version called
             %a{:href=>"https://issues.jboss.org/browse/WFLY/fixforversion/12321689"} Awaiting Volunteers.
             It is usually best to start with something small though like a minor priority bug. If you need help locating a task, feature, or bug to work on, just 
-            %a{:href => "irc://irc.freenode.net/#wildfly"} join our IRC channel 
-            and ask for help. When you do locate an issue be sure to announce you intention in the JIRA so that others don't end up duplicating your effort.
+            %a{:href => "https://www.hipchat.com/gW90m6pIs"} join our HipChat channel 
+            and ask for help. When you do locate an issue be sure to announce your intention in the JIRA so that others don't end up duplicating your effort.
           %h4
             %i.icon-envelope
             Subscribe to our Mailing List
@@ -96,13 +98,16 @@ title: Join Us
                     %a{:href => "https://github.com/wildfly"}Source Code
                   %li
                     %i.icon-pencil
-                    %a{:href => "http://jira.jboss.org/browse/WFLY"}Issue tracker
+                    %a{:href => "http://jira.jboss.org/browse/WFLY"}WildFly Full Issue tracker
+                  %li
+                    %i.icon-pencil
+                    %a{:href => "http://jira.jboss.org/browse/WFCORE"}WildFly Core Issue tracker
                   %li
                     %i.icon-road
                     %a{:href => "https://issues.jboss.org/browse/WFLY#selectedTab=com.atlassian.jira.plugin.system.project%3Aroadmap-panel"}Road Map
                   %li
                     %i.icon-comments
-                    %a{:href => "irc://irc.freenode.net/#wildfly"} IRC 
+                    %a{:href => "https://www.hipchat.com/gW90m6pIs} HipChat
                   %li
                     %i.icon-envelope
                     %a{:href => "https://lists.jboss.org/mailman/listinfo/wildfly-dev"}Developer Discussions Mailing List


### PR DESCRIPTION
I read this page today and it seemed a bit out of date.