### PR TITLE
Community Space and Docs Updates

### DIFF
--- a/_partials/projectfooter.html.haml
+++ b/_partials/projectfooter.html.haml
@@ -8,7 +8,7 @@
         %li
           %a{:href => "#{site.base_url}/gethelp/", :title => "Get Help"} Get Help
         %li
-          %a{:href => "https://community.jboss.org/en/wildfly?view=discussion", :title => "Forums"} Forums
+          %a{:href => "https://groups.google.com/forum/#!forum/wildfly", :title => "Forums"} Forums
         %li
           %a{:href => "#{site.base_url}/downloads/", :title => "Download"} Download
         %li

--- a/_partials/rightcol-downloads.html.haml
+++ b/_partials/rightcol-downloads.html.haml
@@ -16,8 +16,6 @@
       %li.jakarta-ee
         %a{:href => "https://jakarta.ee/specifications/platform/"}
           %img{:alt => "Jakarta EE", :src => "#{site.base_url}/images/JakartaEE_Logo_compatible-color.svg"}
-      %li.tools 
-        %a{:href => "https://docs.jboss.org/author/display/WFLY/Getting+Started+Guide#GettingStartedGuide-WildFly8Configurations"} Full &amp; Web Configs 
       %li.tools
         %a{:href => "http://www.jboss.org/tools"} Supported by Tools
       %li.arquillian

--- a/gethelp.html.haml
+++ b/gethelp.html.haml
@@ -21,7 +21,7 @@ title: Get Help
               %i.icon-thumbs-up.icon-2x.pull-left
               %h4 Etiquette
               If you are asking for help, have you read through the
-              %a{:href => "https://docs.jboss.org/author/display/WFLY/Documentation"} documentation
+              %a{:href => "https://docs.wildfly.org"} documentation
               first?  You may find your answer there.
             %p
               Also, if you are reporting a bug, have you checked our

--- a/gethelp.html.haml
+++ b/gethelp.html.haml
@@ -15,7 +15,7 @@ title: Get Help
           %p
             WildFly's user forums should be your first port of call for any user-related issues with WildFly.  Be it a question, wanting to report a bug, looking for advice, or simply sharing some cool stories you may have.
           %p
-            %a.btn.btn-primary{:href => "https://community.jboss.org/en/wildfly?view=discussions", :role => "button"} Visit the User Forums
+            %a.btn.btn-primary{:href => "https://groups.google.com/forum/#!forum/wildfly", :role => "button"} Visit the User Forums
           .well
             %p
               %i.icon-thumbs-up.icon-2x.pull-left

--- a/joinus.html.haml
+++ b/joinus.html.haml
@@ -118,9 +118,6 @@ title: Join Us
                     %i.icon-wrench
                     %a{:href => "https://community.jboss.org/wiki/HackingOnWildFly"} Hacking On WildFly Guide
                   %li
-                    %i.icon-puzzle-piece
-                    %a{:href => "https://docs.jboss.org/author/display/WFLY8/Extending+WildFly+8"} Extending WildFly
-                  %li
                     %i.icon-book
                     %a{:href => "http://git-scm.com/book"} Pro Git Book
           .row-fluid

--- a/news/2014-02-06-GlassFish-to-WildFly-migration.adoc
+++ b/news/2014-02-06-GlassFish-to-WildFly-migration.adoc
@@ -424,4 +424,4 @@ NOTE: Despite rigorous tests to make sure that the implementation respects all s
 
 To keep this text on the limits of readability, we could not cover all sorts of possibilities. We've focused on those configurations most people need. But you can consider this text as an invitation to give feedback about your particular environment. It will help us to plan future articles about migrating to WildFly.
 
-NOTE: Make sure to report every strange behavior in https://community.jboss.org/en/wildfly?view=discussions[WildFly's forum], https://lists.jboss.org/mailman/listinfo/wildfly-dev[mailing list] or even https://issues.redhat.com/browse/WFLY[submit a bug].
+NOTE: Make sure to report every strange behavior in https://groups.google.com/forum/#!forum/wildfly[WildFly's forum], https://lists.jboss.org/mailman/listinfo/wildfly-dev[mailing list] or even https://issues.redhat.com/browse/WFLY[submit a bug].

--- a/project.properties
+++ b/project.properties
@@ -31,7 +31,7 @@ downloadsLink=https://wildfly.org/downloads/
     
 # Documents
 #######################################################
-docsLink=https://docs.jboss.org/author/display/WFLY/Documentation
+docsLink=https://docs.wildfly.org
     
 # Community links
 #######################################################

--- a/project.properties
+++ b/project.properties
@@ -37,7 +37,7 @@ docsLink=https://docs.wildfly.org
 #######################################################
 communityLink=https://wildfly.org/gethelp/
 knowledgeBaseLink=
-userForumLink=https://developer.jboss.org/en/wildfly
+userForumLink=https://groups.google.com/forum/#!forum/wildfly
 devForumLink=
 mailingListLink=https://lists.jboss.org/mailman/listinfo/wildfly-dev
 chatLink=http://webchat.freenode.net/?channels=wildfly


### PR DESCRIPTION
I noticed a couple spaces pointing to the old documentation links so those were updated or removed where there was not a good replacement for them. Specifically these were config links, which I don't think is needed, and extending WildFly, which again I think is okay to lose.

The other commit is for changing the forum links to Google Groups.

Note I'm not sure if the `project.properties` is used, but I changed those as well in case they are.

I've updated the staging site, https://wildfly.org/staging/, so it can easily be checked before this PR is merged.