### PR TITLE
Replace google tracking with original tag

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -16,7 +16,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
  
-    gtag('config', 'UA-125236544-1');
+    gtag('config', 'UA-40221748-1');
   </script>
 
 


### PR DESCRIPTION
The new site is using the beta site tracking tag. I've replaced it with the original tag so the google analytics will continue in its' historic location. This allows us to have historical data.

Beta Site Analytics (incorrect):
UA-125236544-1

Original Analytics (correct for historical data):
UA-40221748-1