### PR TITLE
[issue209] Remove the /widlflysite prefix from blog post image links …

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,7 +4,7 @@ layout: base
 
 <style type="text/css" media="screen">
   body {
-    background-image: url('/wildflysite/assets/img/wildfly_hero_r3v1.jpg');
+    background-image: url('/assets/img/wildfly_hero_r3v1.jpg');
     background-repeat: no-repeat;
     background-size: 100%;
   }

--- a/_config.yml
+++ b/_config.yml
@@ -57,7 +57,7 @@ asciidoctor:
   base_dir: :docdir
   safe: unsafe
   attributes:
-    imagesdir: /wildflysite/assets/img/news/
+    imagesdir: /assets/img/news/
 
 # Pages permalink
 defaults:

--- a/_data/projectfooter.yml
+++ b/_data/projectfooter.yml
@@ -4,7 +4,7 @@ links:
   - title: Navigation
     subfolderitems:
       - page: Downloads
-        url: /wildflysite/downloads
+        url: /downloads
       - page: Docs
         url: https://docs.wildfly.org
       - page: Github


### PR DESCRIPTION
…as well as the footer downloads and the 404 page image.

resolves #209 