### PR TITLE
[#239] Serve WildFly downloads by HTTPS instead of HTTP

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -796,7 +796,7 @@
    - name: Release Notes
      items:
        - format: Notes
-         url: http://wildfly.org/news/2019/02/27/WildFly16-Final-Released/
+         url: https://wildfly.org/news/2019/02/27/WildFly16-Final-Released/
 - version: 15.0.1.Final
   version_shortname: 15
   date: 2019-01-05
@@ -938,28 +938,28 @@
      items:
        - format: zip
          size: 171 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.zip
        - format: tgz
          size: 170 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 41 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/servlet/wildfly-servlet-14.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/14.0.0.Final/servlet/wildfly-servlet-14.0.0.Final.zip
        - format: tgz
          size: 41 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/servlet/wildfly-servlet-14.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/14.0.0.Final/servlet/wildfly-servlet-14.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 44 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final-src.zip
        - format: tgz
          size: 32 MB
-         url: http://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/14.0.0.Final/wildfly-14.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -968,7 +968,7 @@
    - name: Release Notes
      items:
        - format: Notes
-         url: http://wildfly.org/news/2018/08/30/WildFly14-Final-Released/
+         url: https://wildfly.org/news/2018/08/30/WildFly14-Final-Released/
 - version: 13.0.0.Final
   version_shortname: 13
   date: 2018-05-30
@@ -978,28 +978,28 @@
      items:
        - format: zip
          size: 180 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final.zip
        - format: tgz
          size: 179 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 37 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/servlet/wildfly-servlet-13.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/13.0.0.Final/servlet/wildfly-servlet-13.0.0.Final.zip
        - format: tgz
          size: 37 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/servlet/wildfly-servlet-13.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/13.0.0.Final/servlet/wildfly-servlet-13.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 44 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final-src.zip
        - format: tgz
          size: 31 MB
-         url: http://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/13.0.0.Final/wildfly-13.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1008,7 +1008,7 @@
    - name: Release Notes
      items:
        - format: Notes
-         url: http://wildfly.org/news/2018/05/30/WildFly13-Final-Released/
+         url: https://wildfly.org/news/2018/05/30/WildFly13-Final-Released/
 - version: 12.0.0.Final
   version_shortname: 12
   date: 2018-02-28
@@ -1018,28 +1018,28 @@
      items:
        - format: zip
          size: 162 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.zip
        - format: tgz
          size: 161 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 37 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/servlet/wildfly-servlet-12.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/12.0.0.Final/servlet/wildfly-servlet-12.0.0.Final.zip
        - format: tgz
          size: 36 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/servlet/wildfly-servlet-12.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/12.0.0.Final/servlet/wildfly-servlet-12.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 43 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final-src.zip
        - format: tgz
          size: 31 MB
-         url: http://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/12.0.0.Final/wildfly-12.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1048,7 +1048,7 @@
    - name: Release Notes
      items:
        - format: Notes
-         url: http://wildfly.org/news/2018/02/28/WildFly12-Final-Released/
+         url: https://wildfly.org/news/2018/02/28/WildFly12-Final-Released/
 - version: 11.0.0.Final
   version_shortname: 11
   date: 2017-10-23
@@ -1058,28 +1058,28 @@
      items:
        - format: zip
          size: 152 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.zip
        - format: tgz
          size: 151 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 35 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/servlet/wildfly-servlet-11.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/11.0.0.Final/servlet/wildfly-servlet-11.0.0.Final.zip
        - format: tgz
          size: 34 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/servlet/wildfly-servlet-11.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/11.0.0.Final/servlet/wildfly-servlet-11.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 36 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final-src.zip
        - format: tgz
          size: 24 MB
-         url: http://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/11.0.0.Final/wildfly-11.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1088,7 +1088,7 @@
    - name: Release Notes
      items:
        - format: Notes
-         url: http://wildfly.org/news/2017/10/23/WildFly11-Final-Released/
+         url: https://wildfly.org/news/2017/10/23/WildFly11-Final-Released/
 - version: 10.1.0.Final
   version_shortname: 10
   date: 2016-08-19
@@ -1098,34 +1098,34 @@
      items:
        - format: zip
          size: 134 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.zip
+         url: https://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.zip
        - format: tgz
          size: 133 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 28 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/servlet/wildfly-servlet-10.1.0.Final.zip
+         url: https://download.jboss.org/wildfly/10.1.0.Final/servlet/wildfly-servlet-10.1.0.Final.zip
        - format: tgz
          size: 28 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/servlet/wildfly-servlet-10.1.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/10.1.0.Final/servlet/wildfly-servlet-10.1.0.Final.tar.gz
    - name: Update Existing 10.0.0 Final Install
      licence: LGPL
      items:
        - format: zip
          size: 94 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-update.zip
+         url: https://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-update.zip
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 27 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-src.zip
        - format: tgz
          size: 15 MB
-         url: http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1141,28 +1141,28 @@
      items:
        - format: zip
          size: 132 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.zip
        - format: tgz
          size: 131 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 28 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/servlet/wildfly-servlet-10.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/10.0.0.Final/servlet/wildfly-servlet-10.0.0.Final.zip
        - format: tgz
          size: 28 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/servlet/wildfly-servlet-10.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/10.0.0.Final/servlet/wildfly-servlet-10.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 25 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final-src.zip
        - format: tgz
          size: 15 MB
-         url: http://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/10.0.0.Final/wildfly-10.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1172,7 +1172,7 @@
      licence:
      items:
        - format: Notes
-         url: http://wildfly.org/news/2016/01/29/WildFly10-Released/
+         url: https://wildfly.org/news/2016/01/29/WildFly10-Released/
 - version: 9.0.2.Final
   version_shortname: 9
   date: 2015-10-26
@@ -1182,40 +1182,40 @@
      items:
        - format: zip
          size: 130 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.zip
        - format: tgz
          size: 129 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final.tar.gz
    - name: Update Existing 9.0.1 Final (Patched) Install
      licence: LGPL
      items:
        - format: zip
          size: 50 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-update.zip
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-update.zip
    - name: Update Existing 9.0.1 Final (Full Zip) Install
      licence: LGPL
      items:
        - format: zip
          size: 50 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-901FULLZIP-update.zip
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-901FULLZIP-update.zip
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/servlet/wildfly-servlet-9.0.2.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.2.Final/servlet/wildfly-servlet-9.0.2.Final.zip
        - format: tgz
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/servlet/wildfly-servlet-9.0.2.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.2.Final/servlet/wildfly-servlet-9.0.2.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 24 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-src.zip
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-src.zip
        - format: tgz
          size: 14 MB
-         url: http://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.2.Final/wildfly-9.0.2.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1235,34 +1235,34 @@
      items:
        - format: zip
          size: 127 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final.zip
        - format: tgz
          size: 126 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final.tar.gz
    - name: Update Existing 9.0.0 Final Install
      licence: LGPL
      items:
        - format: zip
          size: 3 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-update.zip
+         url: https://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-update.zip
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/servlet/wildfly-servlet-9.0.1.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.1.Final/servlet/wildfly-servlet-9.0.1.Final.zip
        - format: tgz
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/servlet/wildfly-servlet-9.0.1.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.1.Final/servlet/wildfly-servlet-9.0.1.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 24 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-src.zip
+         url: https://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-src.zip
        - format: tgz
          size: 14 MB
-         url: http://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.1.Final/wildfly-9.0.1.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1272,7 +1272,7 @@
      licence:
      items:
        - format: Notes
-         url: http://wildfly.org/news/2015/07/23/WildFly-901-and-821
+         url: https://wildfly.org/news/2015/07/23/WildFly-901-and-821
 - version: 9.0.0.Final
   version_shortname: 9
   date: 2015-07-02
@@ -1282,28 +1282,28 @@
      items:
        - format: zip
          size: 127 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final.zip
        - format: tgz
          size: 126 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final.tar.gz
    - name: Servlet-Only Distribution
      licence: LGPL
      items:
        - format: zip
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/servlet/wildfly-servlet-9.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/9.0.0.Final/servlet/wildfly-servlet-9.0.0.Final.zip
        - format: tgz
          size: 27 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/servlet/wildfly-servlet-9.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.0.Final/servlet/wildfly-servlet-9.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 24 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final-src.zip
        - format: tgz
          size: 14 MB
-         url: http://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/9.0.0.Final/wildfly-9.0.0.Final-src.tar.gz
    - name: Quick Start Source Code
      licence: AL
      items:
@@ -1313,7 +1313,7 @@
      licence:
      items:
        - format: Notes
-         url: http://wildfly.org/news/2015/07/02/WildFly9-Final-Released
+         url: https://wildfly.org/news/2015/07/02/WildFly9-Final-Released
 - version: 8.2.1.Final
   version_shortname: 8
   date: 2015-07-23
@@ -1323,30 +1323,30 @@
      items:
        - format: zip
          size: 127 MB
-         url: http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.zip
+         url: https://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.zip
        - format: tgz
          size: 113 MB
-         url: http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz
+         url: https://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final.tar.gz
    - name: Update Existing 8.2.0 Final Install
      licence: LGPL
      items:
        - format: zip
          size: 30 MB
-         url: http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-update.zip
+         url: https://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-update.zip
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 25 MB
-         url: http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-src.zip
+         url: https://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-src.zip
        - format: tgz
          size: 15 MB
-         url: http://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/8.2.1.Final/wildfly-8.2.1.Final-src.tar.gz
    - name: Release Notes
      licence:
      items:
        - format: Notes
-         url: http://wildfly.org/news/2015/07/23/WildFly-901-and-821
+         url: https://wildfly.org/news/2015/07/23/WildFly-901-and-821
 - version: 8.2.0.Final
   version_shortname: 8
   date: 2014-11-20
@@ -1356,30 +1356,30 @@
      items:
        - format: zip
          size: 126 MB
-         url: http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip
+         url: https://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.zip
        - format: tgz
          size: 113 MB
-         url: http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final.tar.gz
    - name: Update Existing 8.1.0 Final Install
      licence: LGPL
      items:
        - format: zip
          size: 62 MB
-         url: http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-update.zip
+         url: https://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-update.zip
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 36 MB
-         url: http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-src.zip
        - format: tgz
          size: 22 MB
-         url: http://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/8.2.0.Final/wildfly-8.2.0.Final-src.tar.gz
    - name: Release Notes
      licence: LGPL
      items:
        - format: Notes
-         url: http://wildfly.org/news/2014/11/20/WildFly82-Final-Released
+         url: https://wildfly.org/news/2014/11/20/WildFly82-Final-Released
 - version: 8.1.0.Final
   version_shortname: 8
   date: 2014-05-30
@@ -1389,25 +1389,25 @@
      items:
        - format: zip
          size: 124 MB
-         url: http://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final.zip
+         url: https://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final.zip
        - format: tgz
          size: 111 MB
-         url: http://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final.tar.gz
    - name: Update Existing 8.0.0 Final Install
      licence: LGPL
      items:
        - format: zip
          size: 110 MB
-         url: http://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-update.zip
+         url: https://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-update.zip
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 30 MB
-         url: http://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-src.zip
        - format: tgz
          size: 17 MB
-         url: http://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/8.1.0.Final/wildfly-8.1.0.Final-src.tar.gz
    - name: Release Notes
      licence:
      items:
@@ -1422,21 +1422,21 @@
      items:
        - format: zip
          size: 148 MB
-         url: http://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final.zip
+         url: https://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final.zip
        - format: tgz
          size: 134 MB
-         url: http://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final.tar.gz
+         url: https://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final.tar.gz
    - name: Application Server Source Code
      licence: LGPL
      items:
        - format: zip
          size: 29 MB
-         url: http://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final-src.zip
+         url: https://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final-src.zip
        - format: tgz
          size: 17 MB
-         url: http://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final-src.tar.gz
+         url: https://download.jboss.org/wildfly/8.0.0.Final/wildfly-8.0.0.Final-src.tar.gz
    - name: Release Notes
      licence:
      items:
        - format: Notes
-         url: http://wildfly.org/news/2014/02/11/WildFly8-Final-Released/
+         url: https://wildfly.org/news/2014/02/11/WildFly8-Final-Released/


### PR DESCRIPTION
This fixes #239 