### PR TITLE
WildFly 24 Beta1 release announcement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,7 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 
+# Presently required for Ruby 3 - https://github.com/jekyll/jekyll/issues/8523
+# Looks to be addressed in jekyll 4.3
+gem "webrick"
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -81,6 +82,7 @@ DEPENDENCIES
   jekyll-paginate-v2
   minima (~> 2.5)
   tzinfo-data
+  webrick
 
 BUNDLED WITH
-   2.2.16
+   2.2.19

--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,3 +1,68 @@
+- version: 24.0.0.Beta1
+  version_shortname: 24 Beta1
+  date: 2021-06-04
+  link:
+   - name: WildFly Preview EE 9 Distribution
+     licence: LGPL
+     items:
+       - format: zip
+         size: 200 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.zip
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.zip.sha1
+       - format: tgz
+         size: 199 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.tar.gz
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.tar.gz.sha1
+   - name: Jakarta EE 8 Full & Web Distribution
+     licence: LGPL
+     items:
+       - format: zip
+         size: 203 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.zip
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.zip.sha1
+       - format: tgz
+         size: 202 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.tar.gz
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.tar.gz.sha1
+   - name: Servlet-Only Distribution
+     licence: LGPL
+     items:
+       - format: zip
+         size: 52 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.zip
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.zip.sha1
+       - format: tgz
+         size: 52 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.tar.gz
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.tar.gz.sha1
+   - name: Application Server Source Code
+     licence: LGPL
+     items:
+       - format: zip
+         size: 40 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1-src.zip
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1-src.zip.sha1
+       - format: tgz
+         size: 25 MB
+         url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1-src.tar.gz
+         checksum: SHA-1
+         checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1-src.tar.gz.sha1
+   - name: Quick Start Source Code
+     licence: AL
+     items:
+       - format: Source
+         url: https://github.com/wildfly/quickstart/tree/24.0.0.Beta1
+   - name: Release Notes
+     items:
+       - format: Notes
+         url: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12352775
 - version: 23.0.2.Final
   version_shortname: 23.0.2
   date: 2021-04-29
@@ -193,71 +258,6 @@
       items:
         - format: Notes
           url: https://wildfly.org/news/2021/03/11/WildFly23-Final-Released/
-- version: 23.0.0.Beta1
-  version_shortname: 23 Beta1
-  date: 2021-02-25
-  link:
-   - name: WildFly Preview EE 9 Distribution
-     licence: LGPL
-     items:
-       - format: zip
-         size: 200 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-preview-23.0.0.Beta1.zip
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-preview-23.0.0.Beta1.zip.sha1
-       - format: tgz
-         size: 199 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-preview-23.0.0.Beta1.tar.gz
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-preview-23.0.0.Beta1.tar.gz.sha1
-   - name: Jakarta EE 8 Full & Web Distribution
-     licence: LGPL
-     items:
-       - format: zip
-         size: 203 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1.zip
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1.zip.sha1
-       - format: tgz
-         size: 202 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1.tar.gz
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1.tar.gz.sha1
-   - name: Servlet-Only Distribution
-     licence: LGPL
-     items:
-       - format: zip
-         size: 52 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/servlet/wildfly-servlet-23.0.0.Beta1.zip
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/servlet/wildfly-servlet-23.0.0.Beta1.zip.sha1
-       - format: tgz
-         size: 52 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/servlet/wildfly-servlet-23.0.0.Beta1.tar.gz
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/servlet/wildfly-servlet-23.0.0.Beta1.tar.gz.sha1
-   - name: Application Server Source Code
-     licence: LGPL
-     items:
-       - format: zip
-         size: 40 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1-src.zip
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1-src.zip.sha1
-       - format: tgz
-         size: 25 MB
-         url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1-src.tar.gz
-         checksum: SHA-1
-         checksum_url: https://download.jboss.org/wildfly/23.0.0.Beta1/wildfly-23.0.0.Beta1-src.tar.gz.sha1
-   - name: Quick Start Source Code
-     licence: AL
-     items:
-       - format: Source
-         url: https://github.com/wildfly/quickstart/tree/23.0.0.Beta1
-   - name: Release Notes
-     items:
-       - format: Notes
-         url: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12352712
 - version: 22.0.1.Final
   version_shortname: 22.0.1
   date: 2021-02-11

--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -6,12 +6,12 @@
      licence: LGPL
      items:
        - format: zip
-         size: 200 MB
+         size: 199 MB
          url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.zip
          checksum: SHA-1
          checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.zip.sha1
        - format: tgz
-         size: 199 MB
+         size: 198 MB
          url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.tar.gz
          checksum: SHA-1
          checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-preview-24.0.0.Beta1.tar.gz.sha1
@@ -19,12 +19,12 @@
      licence: LGPL
      items:
        - format: zip
-         size: 203 MB
+         size: 202 MB
          url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.zip
          checksum: SHA-1
          checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.zip.sha1
        - format: tgz
-         size: 202 MB
+         size: 201 MB
          url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.tar.gz
          checksum: SHA-1
          checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/wildfly-24.0.0.Beta1.tar.gz.sha1
@@ -32,7 +32,7 @@
      licence: LGPL
      items:
        - format: zip
-         size: 52 MB
+         size: 53 MB
          url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.zip
          checksum: SHA-1
          checksum_url: https://download.jboss.org/wildfly/24.0.0.Beta1/servlet/wildfly-servlet-24.0.0.Beta1.zip.sha1

--- a/_posts/2021-06-04-WildFly24-Beta-Released.adoc
+++ b/_posts/2021-06-04-WildFly24-Beta-Released.adoc
@@ -1,0 +1,30 @@
+---
+layout: post
+title:  "New WildFly 24 Beta1 release"
+date:   2021-06-04
+tags:   announcement release
+author: bstansberry
+description: WildFly 24 Beta1 is now available for download.
+---
+
+= WildFly 24 Beta1 is released!
+
+I'm pleased to announce that the new WildFly and WildFly Preview 24.0.0.Beta1 releases are available for download at https://wildfly.org/downloads.
+
+Work during the WildFly 24 development cycle has been primarily oriented toward bug fixing, plus the link:https://www.wildfly.org/news/2021/04/29/WildFly2302-Released/[Jakarta EE 9.1 certification work done for WildFly 23].
+
+But I do want to express my special thanks to Sonia Zaldana, a great contributor to WildFly over the past year, who has added three new features in WildFly 24 Beta1:
+
+* link:https://issues.redhat.com/browse/WFCORE-5027[Security Realm support for specifying the charset and encoding for credentials.]
+* link:https://issues.redhat.com/browse/WFCORE-5145[Additional Elytron server-ssl-context allowed protocols.]
+* link:https://issues.redhat.com/browse/WFCORE-5170[Certificate revocation lists]
+
+The other area of focus during this development cycle was improving how WildFly, particularly WildFly Preview, runs on JDK 16 and the early access releases of the next LTS JDK release, JDK 17. There are still some issues to resolve, but WildFly Preview 24 Beta1 runs well enough on the latest JDKs that it's worthwhile for people interested in what JDK 17 will mean for their application to give it a look.
+
+The release notes for the release are link:https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12352775[here], with issues fixed in the underlying WildFly Core betas listed link:https://issues.redhat.com/issues/?jql=project%20%3D%20WFCORE%20AND%20statusCategory%20%3D%20Done%20AND%20fixVersion%20in%20(16.0.0.Beta1%2C%2016.0.0.Beta2%2C%2016.0.0.Beta3%2C%2016.0.0.Beta4%2C%2016.0.0.Beta5)%20ORDER%20BY%20issuetype%20DESC%2C%20key%20ASC%2C%20priority%20DESC[here].
+
+Please try it out and give us your feedback, while we get to work WildFly 24 Final!
+
+Best regards,
+
+Brian


### PR DESCRIPTION
Supersedes https://github.com/wildfly/wildfly.org/pull/265

Minor corrections to download versions and also add webrick as missing when using Ruby 3.
 