### PR TITLE
[Issue 288] Move off the disabled ubuntu-16.04 runner to the current …

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: helaili/jekyll-action@2.0.1


### PR DESCRIPTION
…LTS ubuntu-20.04

Using ubuntu-latest is also and option but for today I'm sticking with a specific version.

Resolves #288 