### PR TITLE
Add a release qualifier for releases.

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,6 +1,7 @@
 - version: 25.0.0.Beta1
   version_shortname: 25 Beta1
   date: 2021-09-20
+  qualifier: Beta
   link:
     - name: WildFly Preview EE 9.1 Distribution
       licence: LGPL

--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -25,7 +25,7 @@ layout: base
             <div class="grid__item width-6-12 version-table">
               <table class="tg">
                 <tr>
-                  <th colspan="3"><div class="version-name final">final<span class="release-date">{{versionId.date | date: "%b %d, %Y" }}</span></div>
+                  <th colspan="3"><div class="version-name final">{{versionId.qualifier | default: "Final" }}<span class="release-date">{{versionId.date | date: "%b %d, %Y" }}</span></div>
                 </tr>
                 {% for releaseItem in versionId.link %}
                 <tr>


### PR DESCRIPTION
I noticed that above every release we have the word "Final" even for the Beta releases.  

This allows an additional "qualifier" to be optionally defined.  I have only needed to add the "qualifier" to the most recent Beta as older Betas are removed - we could use a different qualifier for the micros if we wanted to flag them as "Maintenance".
