### PR TITLE
Add special handling for posts that link to vlogs and add posts that link to the three vlogs on the WildFly YouTube channel

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -144,3 +144,9 @@ araskar:
   occupation: "Software Engineer"
   bio: "Ashpan works at Red Hat as a Software Engineering Intern on WildFly Elytron team."
   twitter: "ashpanr"
+smaestri:
+  name: "Stefano Maestri"
+  location: "Italy"
+  occupation: "Manager"
+  twitter: "maeste"
+

--- a/_includes/news-list-blocks.html
+++ b/_includes/news-list-blocks.html
@@ -15,7 +15,7 @@
         {% else %}
           <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
         {% endif %}
-        <a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>Read More ></a>
+        <a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{% if post.link contains 'youtube' %}Watch Video >{% else %}Read More >{% endif %}</a>
       </div>
     {% endif %}
   {% endfor %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -29,7 +29,7 @@ layout: base
             <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
           {% endif %}
         </div>
-        <div class="grid__item width-12-12"><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>Read More ></a></div>
+        <div class="grid__item width-12-12"><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{% if post.link contains 'youtube' %}Watch Video >{% else %}Read More >{% endif %}</a></div>
       </div>
     {% endfor %}
     {% if paginator.total_pages > 1 %}

--- a/_posts/2022-04-04-build-deploy-wildfly-quickstarts-openshift.adoc
+++ b/_posts/2022-04-04-build-deploy-wildfly-quickstarts-openshift.adoc
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  'Vlog: Build and Deploy WildFly Quickstarts on OpenShift'
+date:   2022-04-04
+tags:   wildfly quickstarts openshift vlog
+synopsis: This video demonstrates how to build and deploy a quickstart for WildFly on OpenShift.
+author: jmesnil
+link: https://www.youtube.com/watch?v=Y2En5miRKjY
+---

--- a/_posts/2022-04-04-introducing-wildfly-as-youtube-channel.adoc
+++ b/_posts/2022-04-04-introducing-wildfly-as-youtube-channel.adoc
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  'Vlog: Introducing the wildfly.org YouTube Channel'
+date:   2022-04-04
+tags:   wildfly vlog
+synopsis: This video gives an introduction to WildFly's new YouTube channel.
+author: smaestri
+link: https://www.youtube.com/watch?v=cRDv_Oi-7T8
+---

--- a/_posts/2022-04-04-securing-wildfly-apps-oidc-openshift.adoc
+++ b/_posts/2022-04-04-securing-wildfly-apps-oidc-openshift.adoc
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  'Vlog: Securing a WildFly Application with OpenID Connect on OpenShift'
+date:   2022-04-04
+tags:   oidc openshift vlog
+synopsis: This video demonstrates how to secure an application deployed to WildFly on OpenShift with OpenID Connect.
+author: fjuma
+link: https://www.youtube.com/watch?v=2gQO4_7Z5CI
+---


### PR DESCRIPTION
We made a similar change to the Elytron website as well so we can link to vlogs in addition to blog posts. Here's what it looks like there:

https://wildfly-security.github.io/wildfly-elytron/blog/