### PR TITLE
Page titles & code formatting improvements

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,7 +5,7 @@
   <script id="adobe_dtm" src="//www.redhat.com/dtm.js" type="text/javascript"></script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>WildFly</title>
+  <title>{{ page.title  | default: site.title }}</title>
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <link rel="shortcut icon" type="image/png" href="{{ "/favicon.ico" | prepend: site.baseurl }}" >
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />

--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -163,6 +163,7 @@ code, pre {
   line-height: 1.2;
   overflow: scroll;
   padding: 0 5px;
+  max-width: $content-width;
 }
 
 pre {

--- a/_sass/includes/header.scss
+++ b/_sass/includes/header.scss
@@ -3,7 +3,6 @@
 // It does not contain the YAML front matter and has no corresponding output file in the built site.
 
 // Navigation Variables
-$content-width: 1000px;
 $nav-breakpoint: 1024px;
 $nav-height: 70px;
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,6 +4,7 @@
 ---
 
 $baseurl: "{{ site.baseurl }}";
+$content-width: 1000px;
 
 @import "global";
 @import "grid";


### PR DESCRIPTION
* If a page defines {{ page.title }} variable, it will be used as page
  title (the text displays in the browser/tab window title). This is
  somewhat important for SEO, but mainly has UX value as users can tell
  what page a browser tab contains.
* Set max-width on \<pre\> elements, so that if a \<pre\> contains long line,
  it doesn't stretch the whole page, but the \<pre\> shows a horizontal
  scroll bar instead.