### PR TITLE
Use more descriptive page titles for the 'About' and 'Downloads' pages

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,7 +5,7 @@
   <script id="adobe_dtm" src="//www.redhat.com/dtm.js" type="text/javascript"></script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>WildFly</title>
+  <title>{{ page.title  | default: site.title }}</title>
   <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
   <link rel="shortcut icon" type="image/png" href="{{ "/favicon.ico" | prepend: site.baseurl }}" >
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />

--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -163,6 +163,7 @@ code, pre {
   line-height: 1.2;
   overflow: scroll;
   padding: 0 5px;
+  max-width: $content-width;
 }
 
 pre {

--- a/_sass/includes/header.scss
+++ b/_sass/includes/header.scss
@@ -3,7 +3,6 @@
 // It does not contain the YAML front matter and has no corresponding output file in the built site.
 
 // Navigation Variables
-$content-width: 1000px;
 $nav-breakpoint: 1024px;
 $nav-height: 70px;
 

--- a/about.md
+++ b/about.md
@@ -1,5 +1,5 @@
 ---
 layout: about
-title: About
+title: About WildFly
 permalink: /about/
 ---

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,6 +4,7 @@
 ---
 
 $baseurl: "{{ site.baseurl }}";
+$content-width: 1000px;
 
 @import "global";
 @import "grid";

--- a/downloads.md
+++ b/downloads.md
@@ -1,5 +1,5 @@
 ---
 layout: downloads
-title: Downloads
+title: WildFly Downloads
 permalink: /downloads/
 ---


### PR DESCRIPTION
Builds on #338 by adding context to  a couple page titles