### PR TITLE
Add an option to override the current releases index.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,9 @@ twitter_username: WildFlyAS
 github_username:  wildfly
 chatroom_url: "https://wildfly.zulipchat.com/"
 forum_url: "https://groups.google.com/forum/#!forum/wildfly"
+# This should typically be 0. However, in some cases we might want a different index to be used. For example if a micro
+# is released, but we still want to advertise the newest minor or major.
+current_release_index: 1
 
 # Build settings
 markdown: kramdown

--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -5,7 +5,7 @@ layout: base
 <div class="wildfly-downloads">
   <div class="grid-wrapper">
     <div class="grid__item width-12-12 ">
-      {% assign latestRelease = site.data.releases[0] %}
+      {% assign latestRelease = site.data.releases[site.current_release_index] %}
       <h1>Wild<strong>Fly</strong> {{ latestRelease.version_shortname }} is now available</h1>
       <div class="download-ctas">
         <a href="https://github.com/wildfly/wildfly/releases/download/{{latestRelease.version}}/wildfly-{{latestRelease.version}}.zip" class="button-cta">Download the zip</a>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -5,7 +5,7 @@ layout: base
 <div class="grid-wrapper">
   <div class="grid__item width-12-12 home-section">
 
-    {% assign latestRelease = site.data.releases[0] %}
+    {% assign latestRelease = site.data.releases[site.current_release_index] %}
     <h1>Wild<strong>Fly</strong> {{latestRelease.version_shortname}} is now available</h1>
     <div class="home-ctas">
       


### PR DESCRIPTION
This changes the current release from 26.1.3.Final to 27.0.1.Final. Also introduces a new configuration parameter to easily adjust this. For example on the next release we'd make the `current_release_index: 0` for the latest release.