### PR TITLE
Add links anchor links to download versions.

### DIFF
--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -18,7 +18,7 @@ layout: base
       {% for versionId in site.data.releases %}
       <div class="grid-wrapper version-row mobile-fullwidth">
         <div class="grid__item width-2-12 version-id">
-          <h2>{{ versionId.version }}</h2>
+          <h2 id="{{ versionId.version }}"><a class="anchor" href="#{{ versionId.version }}"></a>{{ versionId.version }}</h2>
         </div>
         <div class="grid__item width-10-12 version-content">
           <div class="grid-wrapper">

--- a/_sass/layouts/downloads.scss
+++ b/_sass/layouts/downloads.scss
@@ -58,6 +58,36 @@
       grid-column: span 12;
     }
   }
+
+
+  h1>a.anchor, h2>a.anchor, h3>a.anchor, h4>a.anchor, h5>a.anchor, h6>a.anchor {
+    position: absolute;
+    z-index: 1001;
+    width: 1.5ex;
+    margin-left: -1.2ex;
+    display: block;
+    text-decoration: none!important;
+    visibility: hidden;
+    text-align: center;
+    font-weight: 400;
+  }
+
+  h1>a.anchor::before, h2>a.anchor::before, h3>a.anchor::before,
+  h4>a.anchor::before, h5>a.anchor::before, h6>a.anchor::before {
+    content: "\00A7";
+    font-size: .75em;
+    display: block;
+    padding-top: 0.1em;
+  }
+
+  h1:hover > a.anchor, h1 > a.anchor:hover,
+  h2:hover > a.anchor, h2 > a.anchor:hover,
+  h3:hover > a.anchor, h3 > a.anchor:hover,
+  h4:hover > a.anchor, h4 > a.anchor:hover,
+  h5:hover > a.anchor, h5 > a.anchor:hover,
+  h6:hover > a.anchor, h6 > a.anchor:hover {
+    visibility: visible;
+  }
 }
 
 .version-table {


### PR DESCRIPTION
This results in a link like https://wildfly.org/downloads#27.0.1.Final link to the 27.0.1.Final download row.

Also adds a hover link to the version id.
![image](https://user-images.githubusercontent.com/420065/223835878-bc8c8396-7fc8-4be2-ac4f-6adec8fd2c34.png)
