### PR TITLE
Add support for multiple post authors

### DIFF
--- a/_includes/news-list-blocks.html
+++ b/_includes/news-list-blocks.html
@@ -3,13 +3,16 @@
     <h3>Latest News</h3>
   </div>
   {% for post in site.posts %}
-    {% assign author = site.data.authors[post.author] %}
+    {% assign author = "" | split: ',' %}
+    {% for a in page.author %}
+      {% assign author = author | push: site.data.authors[a].name %}
+    {% endfor %}
     {% if forloop.index <= 8 %}
       <div class="news-block-item grid__item width-3-12">
         <div class="post-title grid__item">
           <h4><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{{ post.title }}</a></h4>
         </div>
-        <p class="byline">By {{ author.name }} | {{ post.date | date: '%B %d, %Y' }}</p>
+        <p class="byline">By {{ author | join: ", " }} | {{ post.date | date: '%B %d, %Y' }}</p>
         {% if post.synopsis %}
           <p>{{ post.synopsis | strip_html }}</p>
         {% else %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -12,14 +12,17 @@ layout: base
   
 
   <div class="grid__item width-10-12 width-12-12-m">
-    {% for post in paginator.posts %}
-      {% assign author = site.data.authors[post.author] %}
+      {% for post in paginator.posts %}
+      {% assign author = "" | split: ',' %}
+      {% for a in post.author %}
+        {% assign author = author | push: site.data.authors[a].name %}
+      {% endfor %}
       <div class="news-list-item grid-wrapper">
         <div class="post-title grid__item width-12-12">
           <h2><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{{ post.title }}</a></h2>
         </div>
         <div class="grid__item width-6-12 width-12-12-m">
-          <p class="byline">By {{ author.name }} | {{ post.date | date: '%B %d, %Y' }}</p>
+          <p class="byline">By {{ author | join: ', ' }} | {{ post.date | date: '%B %d, %Y' }}</p>
         </div>
         <div class="grid__item width-6-12 width-12-12-m">{% include share-page.html %}</div>
         <div class="grid__item width-12-12">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,8 +5,11 @@ layout: base
 <div class="post-page grid-wrapper">
   <div class="grid__item width-10-12">
     <h1 class="title">{{page.title}}</h1>
-    {% assign author = site.data.authors[page.author] %}
-    <p class="byline">By {{ author.name }} | {{ page.date | date: '%B %d, %Y' }}</p>
+    {% assign author = "" | split: ',' %}
+    {% for a in page.author %}
+      {% assign author = author | push: site.data.authors[a].name %}
+    {% endfor %}
+    <p class="byline">By {{ author | join: ', ' }} | {{ page.date | date: '%B %d, %Y' }}</p>
   </div>
   <div class="grid__item width-10-12 doc-content">
     {{ content }}

--- a/_posts/2023-05-22-grpc-subsystem.adoc
+++ b/_posts/2023-05-22-grpc-subsystem.adoc
@@ -3,7 +3,9 @@ layout: post
 title:  "grpc Subsystem in WildFly"
 date:   2023-05-22
 tags:   grpc
-author: rsigal, hpehl
+author:
+  - rsigal
+  - hpehl
 description: Introducing grpc subsystem in WildFly
 ---
 

--- a/feed.xml
+++ b/feed.xml
@@ -35,21 +35,34 @@ layout: null
         <content type="html" xml:base="{% if post.link %}{{ post.link }}{% else %}{{ post.url | absolute_url | xml_escape }}{% endif %}">{{ post.content | strip | xml_escape }}</content>
       {% endunless %}
 
-      {% assign post_author = post.author | default: post.authors[0] | default: site.author %}
-      {% assign post_author = site.data.authors[post_author] | default: post_author %}
-      {% assign post_author_email = post_author.email | default: nil %}
-      {% assign post_author_uri = post_author.uri | default: nil %}
-      {% assign post_author_name = post_author.name | default: post_author %}
+      {% assign post_authors = "" | split: ',' %}
+      {% assign post_authors_emails = "" | split: ',' %}
+      {% assign post_authors_uris = "" | split: ',' %}
+      {% assign post_authors_names = "" | split: ',' %}
+      {% for a in post.author %}
+        {% assign a_data = a | default: site.author %}
+        {% assign a_data = site.data.authors[a_data] | default: a_data %}
+        {% assign a_email = a_data.email | default: nil %}
+        {% assign a_uri = a_data.uri | default: nil %}
+        {% assign a_name = a_data.name | default: a_data %}
 
-      <author>
-        <name>{{ post_author_name | default: "" | xml_escape }}</name>
-        {% if post_author_email %}
-        <email>{{ post_author_email | xml_escape }}</email>
-        {% endif %}
-        {% if post_author_uri %}
-        <uri>{{ post_author_uri | xml_escape }}</uri>
-        {% endif %}
-      </author>
+        {% assign post_authors = post_authors | push: a_data %}
+        {% assign post_authors_emails = post_authors_emails | push: a_email %}
+        {% assign post_authors_uris = post_authors_uris | push: a_uri %}
+        {% assign post_authors_names = post_authors_names | push: a_name %}
+      {% endfor %}
+
+      {% for i in post_authors %}
+        <author>
+          <name>{{ post_authors_names[forloop.index0] | default: "" | xml_escape }}</name>
+          {% if post_authors_emails[forloop.index0] %}
+          <email>{{ post_authors_emails[forloop.index0] | xml_escape }}</email>
+          {% endif %}
+          {% if post_authors_uris[forloop.index0] %}
+          <uri>{{ post_authors_uris[forloop.index0] | xml_escape }}</uri>
+          {% endif %}
+        </author>
+      {% endfor %}
 
       {% if post.category %}
         <category term="{{ post.category | xml_escape }}" />


### PR DESCRIPTION
Uses Liquid for loops to iterate through a list of authors.

Note that `post.author` is used for both single and multiple authors, but formatting as a YAML list is only needed for multiple.