### PR TITLE
Add example for using Certificate Based Authentication with Mutual TLS without roles 

### DIFF
--- a/_data/authors.yaml
+++ b/_data/authors.yaml
@@ -202,3 +202,10 @@ rsigal:
   occupation: Senior Software Engineer
   bio: https://github.com/ronsigal/
   avatar: rsigal.jpg
+prarthonapaul:
+  name: "Prarthona Paul"
+  location: "Toronto, CA"
+  occupation: "Software engineering intern"
+  bio: "Prarthona is a Software Engineering Intern at Red Hat, working on the WildFly Elytron team."
+  emailhash: "6ed81e314d6074bbf734abe812f33b05"
+  twitter: "prarthonapaul"

--- a/_posts/2023-06-26-Client-cert-auth-without-roles.adoc
+++ b/_posts/2023-06-26-Client-cert-auth-without-roles.adoc
@@ -1,0 +1,9 @@
+---
+layout: post
+title: 'Using Certificate Based Authentication with Mutual TLS without Roles'
+date: 2023-06-26
+tags: #authentication #client-cert #tls 
+synopsis: How to secure a web application deployed to WildFly with mutual TLS and the CLIENT_CERT HTTP authentication mechanism.
+author: prarthonapaul
+link: https://wildfly-security.github.io/wildfly-elytron/blog/Client-cert-auth-without-roles/
+---


### PR DESCRIPTION
Wildfly-elytron blog: https://wildfly-security.github.io/wildfly-elytron/blog/Client-cert-auth-without-roles/
WildFly-elytron blog Pull Request: https://github.com/wildfly-security/wildfly-elytron/pull/1913