### PR TITLE
[#383] Add author picture to the blog post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,10 +6,37 @@ layout: base
   <div class="grid__item width-10-12">
     <h1 class="title">{{page.title}}</h1>
     {% assign author = "" | split: ',' %}
+    {% assign has_avatar = "false" %}
     {% for a in page.author %}
       {% assign author = author | push: site.data.authors[a].name %}
+      {% if site.data.authors[a].avatar != nil %}
+        {% assign has_avatar = "true" %}
+      {% endif %}
     {% endfor %}
-    <p class="byline">By {{ author | join: ', ' }} | {{ page.date | date: '%B %d, %Y' }}</p>
+
+    <p>
+      {% if has_avatar == "true" %}
+        {% for a in page.author %}
+          {% assign author_data = site.data.authors[a] %}
+          <p class="byline">
+            {% if author_data.avatar != %}
+              <img class="avatar" height="60px" width="60px" src="/assets/img/authors/{{author_data.avatar}}"/>
+            {% else %}
+              <img class="avatar" height="60px" width="60px" src="/assets/img/contribute/wildfly_icons_contribute-blog.png"/>
+            {% endif %}
+
+            {% if a == page.author.first or page.author.first == nil %}By {% endif %}{{author_data.name}}
+            {% if a != page.author[-1] and page.author.first != nil %}
+              ,
+            {% else %}
+              | {{ page.date | date: '%B %d, %Y' }}
+            {% endif %}
+          </p>
+        {% endfor %}
+      {% else %}
+        <p class="byline">By {{ author | join: ', ' }} | {{ page.date | date: '%B %d, %Y' }}</p>
+      {% endif %}
+    </p>
   </div>
   <div class="grid__item width-10-12 doc-content">
     {{ content }}

--- a/_sass/global.scss
+++ b/_sass/global.scss
@@ -111,6 +111,11 @@ p.byline {
   line-height: 1.8rem;
 }
 
+img.avatar {
+  vertical-align:middle;
+  border-radius: 50%;
+}
+
 a {
   line-height: 1.5rem;
   font-weight: 400;


### PR DESCRIPTION
Fixes #363 

Article with one author with an avatar image:
<img width="500" alt="Screenshot 2023-11-03 at 12 07 15" src="https://github.com/wildfly/wildfly.org/assets/1005243/910955c2-b1fa-4a7c-a430-cd6ce4c68624">

Article with multiple author, all with avatar image:
<img width="500" alt="Screenshot 2023-11-03 at 12 07 37" src="https://github.com/wildfly/wildfly.org/assets/1005243/5d1927f0-86ab-49ef-91d5-d0f25322064c">

Default image when one of authors doesn't have an avatar:
<img width="500" alt="Screenshot 2023-11-03 at 12 07 53" src="https://github.com/wildfly/wildfly.org/assets/1005243/4611f365-37da-4f8a-bfcf-52bc32fac143">


