### PR TITLE
Fix missing authros in news section on home page

### DIFF
--- a/_includes/news-list-blocks.html
+++ b/_includes/news-list-blocks.html
@@ -4,7 +4,7 @@
   </div>
   {% for post in site.posts %}
     {% assign author = "" | split: ',' %}
-    {% for a in page.author %}
+    {% for a in post.author %}
       {% assign author = author | push: site.data.authors[a].name %}
     {% endfor %}
     {% if forloop.index <= 8 %}


### PR DESCRIPTION
This PR brings back the author names in the news section on the homepage