### PR TITLE
Add a link to the OS guide on the getting started page

### DIFF
--- a/_layouts/getstarted.html
+++ b/_layouts/getstarted.html
@@ -9,23 +9,6 @@ layout: base
     <div class="grid__item width-12-12 width-12-12-mobile">
         <div>
             {{ content }}
-            {% comment %}
-            {% This should be part of the content in geststarted.adoc %}
-            {% But since we want to use the variable for the latest WildFly version %}
-            {% to render the link to the OS guide, this is part of the layout %}
-            {% endcomment %}
-            {% assign latestRelease = site.data.releases[site.current_release_index] %}
-            <div class="sect1">
-                <h2 id="next-steps">Next Steps</h2>
-                <div class="sectionbody">
-                    <div class="paragraph">
-                        <p>
-                            To learn more about WildFly, you can read its <a href="https://docs.wildfly.org" target="_blank" rel="noopener">documentation</a>.<br>
-                            If you want to learn how to use WildFly on OpenShift, read the <a href="https://docs.wildfly.org/{{latestRelease.version}}/Getting_Started_on_OpenShift.html" target="_blank" rel="noopener">Getting Started with WildFly on OpenShift Guide</a>
-                        </p>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
     <div class="grid__item width-12-12 width-12-12-mobile">

--- a/_layouts/getstarted.html
+++ b/_layouts/getstarted.html
@@ -9,6 +9,23 @@ layout: base
     <div class="grid__item width-12-12 width-12-12-mobile">
         <div>
             {{ content }}
+            {% comment %}
+            {% This should be part of the content in geststarted.adoc %}
+            {% But since we want to use the variable for the latest WildFly version %}
+            {% to render the link to the OS guide, this is part of the layout %}
+            {% endcomment %}
+            {% assign latestRelease = site.data.releases[site.current_release_index] %}
+            <div class="sect1">
+                <h2 id="next-steps">Next Steps</h2>
+                <div class="sectionbody">
+                    <div class="paragraph">
+                        <p>
+                            To learn more about WildFly, you can read its <a href="https://docs.wildfly.org" target="_blank" rel="noopener">documentation</a>.<br>
+                            If you want to learn how to use WildFly on OpenShift, read the <a href="https://docs.wildfly.org/{{latestRelease.version}}/Getting_Started_on_OpenShift.html" target="_blank" rel="noopener">Getting Started with WildFly on OpenShift Guide</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     <div class="grid__item width-12-12 width-12-12-mobile">

--- a/getstarted.adoc
+++ b/getstarted.adoc
@@ -86,3 +86,8 @@ public String hello(String name) {
 
 Save the file and the application will be recompiled and updated in WildFly. If you access the application at http://localhost:8080,
 it will now return the name in upper case.
+
+== Next Steps
+
+To learn more about WildFly, you can read its https://docs.wildfly.org[documentation,window=_blank]. +
+If you want to learn how to use WildFly on OpenShift, read the https://docs.wildfly.org/{{ site.data.releases | where:"qualifier", "Final" | map: "version" | first | split: "." | first }}/Getting_Started_on_OpenShift.html[Getting Started with WildFly on OpenShift Guide,window=_blank]

--- a/getstarted.adoc
+++ b/getstarted.adoc
@@ -86,7 +86,3 @@ public String hello(String name) {
 
 Save the file and the application will be recompiled and updated in WildFly. If you access the application at http://localhost:8080,
 it will now return the name in upper case.
-
-== Next Steps
-
-To learn more about WildFly, you can read its https://docs.wildfly.org[documentation,window=_blank].


### PR DESCRIPTION
This PR adds a link to the OpenShift guide to the getting started page as discussed in https://issues.redhat.com/browse/EAPENGOKR-94?focusedId=23773952&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23773952

The links should actually be part of the content in `geststarted.adoc`, but I always want to link to the *latest* guide. So I decided to move the links to the layout. If there's a better approach, please let me know. 