### PR TITLE
WildFly mini conference news post

### DIFF
--- a/_posts/2024-01-31-WildFly-mini-conference.adoc
+++ b/_posts/2024-01-31-WildFly-mini-conference.adoc
@@ -1,0 +1,16 @@
+---
+layout: post
+title:  "WildFly Mini Conference"
+date:   2024-01-31
+tags:   announcement conference
+author: hpehl
+description: The WildFly team is hosting a conference.
+---
+
+= WildFly Mini Conference
+
+The WildFly team organizes a conference. The conference will take place on *Wednesday, March 6, 2024*. It starts at *14:00 UTC* and includes *four sessions* with topics related to WildFly. All sessions will be streamed live on YouTube.
+
+For more information, please take a look at the conference page at https://www.wildfly.org/conference/
+
+We're looking forward to seeing you there!

--- a/_posts/2024-01-31-WildFly-mini-conference.adoc
+++ b/_posts/2024-01-31-WildFly-mini-conference.adoc
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "WildFly Mini Conference"
-date:   2024-01-31
+date:   2024-02-12
 tags:   announcement conference
 author: hpehl
 description: The WildFly team is hosting a conference.


### PR DESCRIPTION
This is the PR for the news post about our WildFly mini conference. 

I've kept it pretty short and only listed the most important facts. Everything else can be found on the conference page itself. But I appreciate any suggestions to make it more detailed.

I'm not sure exactly when the news post is supposed to go online. I guess right after the conference page itself is published. In that case, we would have to adjust the name and date of the news post. 

