### PR TITLE
Add a blog on how caching realm can now update obsolete credentials

### DIFF
--- a/_posts/2024-05-06-caching-realm-update-of-credentials.adoc
+++ b/_posts/2024-05-06-caching-realm-update-of-credentials.adoc
@@ -1,0 +1,11 @@
+---
+layout: post
+title:  'Caching realm now automatically tries to authenticate users with the underlying realm if authentication with cached credentials fails'
+date:   2024-05-06
+tags:   elytron security caching realm credentials authentication
+author: dvilkola
+synopsis: Learn how the Caching Realm can now update outdated credentials.
+link: https://wildfly-security.github.io/wildfly-elytron/blog/caching-security-realm-authenticate-with-underlying-realm-on-failure/
+---
+
+WildFly provides a caching security realm that allows you to cache the results of a credential lookup from a security realm. WildFly 32+ will automatically attempt to verify credentials with the underlying realm if an authentication fails with the cached credentials. If this authentication succeeds, the obsolete credential is replaced with the updated credential. This functionality is useful if the credentials have been updated externally of WildFly.


### PR DESCRIPTION
Based on: https://wildfly-security.github.io/wildfly-elytron/blog/caching-security-realm-authenticate-with-underlying-realm-on-failure/
