### PR TITLE
Matomo POC closing, remove code

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -24,8 +24,6 @@
 
     gtag('config', 'UA-40221748-1');
   </script>
-  <script src="{{ site.baseurl }}assets/javascript/tracking.js"></script>
-  <script src="https://design.jboss.org/matomo/matomo.js" async defer></script>
 
   {% if page.link %}
   <meta http-equiv="refresh" content="0; {{ page.link }}">

--- a/assets/javascript/tracking.js
+++ b/assets/javascript/tracking.js
@@ -1,8 +1,0 @@
-var idSite = 5;
-var matomoTrackingApiUrl = 'https://analytics.ossupstream.org/matomo.php';
-
-var _paq = window._paq = window._paq || [];  
-_paq.push(['setTrackerUrl', matomoTrackingApiUrl]);
-_paq.push(['setSiteId', idSite]);
-_paq.push(['trackPageView']);
-_paq.push(['enableLinkTracking']);  


### PR DESCRIPTION
The Matomo POC has run it's course and is being sunset. I've removed the associated code from the Wildfly site. We're currently trying to have in internal instance of Matomo that is fully supported. I'll reach out once we get it up and running.