### PR TITLE
[#611] Add a /releases page

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -8,7 +8,18 @@ layout: base
     {% assign latestRelease = site.data.releases[site.current_release_index] %}
     <h1>Wild<strong>Fly</strong></h1>
     <h2>A powerful, modular, & lightweight application server that helps you build amazing applications.</h2>
-    <h3>Now available: <span style="font-weight: 100;">Wild</span><strong>Fly</strong> {{latestRelease.version_shortname}}</h3>
+
+    {% for link in latestRelease.link %}
+      {% if link.name == "Release Notes" %}
+        {% for item in link.items %}
+          {% if item.format == "Notes" %}
+            {% assign releaseNoteLink = item.url %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+
+    <h3>Now available: <a href="{{ releaseNoteLink }}"><span style="font-weight: 100;">Wild</span><strong>Fly</strong> {{latestRelease.version_shortname}}</a></h3>
     <div class="home-ctas">
       <a href="{{site.baseurl}}/downloads/" class="button-cta secondary">Download Wild<strong>Fly</strong></a>
       <a href="{{site.baseurl}}/get-started/" class="button-cta">Get Started</a>

--- a/_layouts/releases.html
+++ b/_layouts/releases.html
@@ -4,23 +4,20 @@ layout: base
 
 <div class="news-page grid-wrapper">
   <div class="grid__item width-10-12">
-    <h1 class="title">Wild<strong>Fly</strong> Project News</h1>
+    <h1 class="title">Wild<strong>Fly</strong> Releases</h1>
   </div>
   <div class="grid__item width-2-12 rss-btn">
     <a href="{{site.baseurl}}/feed.xml"><i class="fas fa-rss-square"></i></a>
   </div>
 
-  <div class="grid__item width-10-12 width-12-12-m">
-    <a href="{{ site.baseurl }}/releases" class="button-cta secondary">Release Announcements</a>
-  </div>
-
 
   <div class="grid__item width-10-12 width-12-12-m">
-      {% for post in paginator.posts %}
-      {% assign author = "" | split: ',' %}
-      {% for a in post.author %}
-        {% assign author = author | push: site.data.authors[a].name %}
-      {% endfor %}
+      {% for post in site.posts %}
+        {% if post.tags contains 'release' and post.tags  contains 'announcement' %}
+          {% assign author = "" | split: ',' %}
+            {% for a in post.author %}
+              {% assign author = author | push: site.data.authors[a].name %}
+            {% endfor %}
       <div class="news-list-item grid-wrapper">
         <div class="post-title grid__item width-12-12">
           <h2><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{{ post.title }}</a></h2>
@@ -38,18 +35,8 @@ layout: base
         </div>
         <div class="grid__item width-12-12"><a href="{% if post.link %}{{ post.link }}{% else %}{{site.baseurl}}{{ post.url }}{% endif %}" {% if post.link %}target="_blank"{% endif %}>{% if post.link contains 'youtube' %}Watch Video >{% else %}Read More >{% endif %}</a></div>
       </div>
-    {% endfor %}
-    {% if paginator.total_pages > 1 %}
-      <div class="paginator-btns">
-        {%- capture visibility -%}
-        {%- if paginator.previous_page -%}visible{%- else -%}hidden{%- endif -%}
-        {%- endcapture -%}
-        <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}" class="button-cta secondary" style="visibility: {{visibility}}">Newer Posts</a>
-        {% if paginator.next_page %}
-          <a href="{{ paginator.next_page_path | prepend: site.baseurl }}" class="button-cta secondary">Older Posts</a>
         {% endif %}
-      </div>
-    {% endif %}
+      {% endfor %}
   </div>
 
   <div class="grid__item width-2-12"></div>

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,5 @@
+---
+layout: releases
+title: "WildFly Release Announcements"
+permalink: /releases/
+---


### PR DESCRIPTION
The /releases page lists the Release announcements from WildFly (based on the tags "release announcement") to provide a one-page destination for all WildFly releases.

This fixes #611