### PR TITLE
Fix links on get-started-microservices-on-kubernetes.adoc

### DIFF
--- a/guides/get-started-microservices-on-kubernetes.adoc
+++ b/guides/get-started-microservices-on-kubernetes.adoc
@@ -18,14 +18,14 @@ We will start building a link:https://docs.docker.com/[Docker Image, window="_bl
 
 === Guides in this series
 
-* link:simple-microservice-part1[{simple-microservice-part1}]
-* link:simple-microservice-part2[{simple-microservice-part2}]
-* link:simple-microservice-database-part1[{simple-microservice-database-part1}]
-* link:simple-microservice-database-part2[{simple-microservice-database-part2}]
-* link:simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}]
-* link:simple-microservice-infinispan-part2[{simple-microservice-infinispan-part2}]
-* link:simple-microservice-jms-part1[{simple-microservice-jms-part1}]
-* link:simple-microservice-jms-part2[{simple-microservice-jms-part2}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[{simple-microservice-database-part1}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2[{simple-microservice-database-part2}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2[{simple-microservice-infinispan-part2}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[{simple-microservice-jms-part1}]
+* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2[{simple-microservice-jms-part2}]
 //* link:get-enterprise-ready[{get-enterprise-ready}]
 
 [[references]]


### PR DESCRIPTION
When running locally with:
```shell
bundle exec jekyll serve
```
the resulting urls for links on page https://www.wildfly.org/guides/get-started-microservices-on-kubernetes are like:
http://127.0.0.1:4000/guides/get-started-microservices-on-kubernetes/simple-microservice-part1

but when looking at the deployed site the ulrs are missing the `get-started-microservices-on-kubernetes` token and the user gets:

```html
Error '404'
ERROR FOUR O’ FOUR
LOST IN THE WildFly MOUNTAINS
YOU SHOULD TRY THE NAV
```