### PR TITLE
Remove site.baseurl variables from adoc since it has no configruation

### DIFF
--- a/guides/get-started-microservices-on-kubernetes.adoc
+++ b/guides/get-started-microservices-on-kubernetes.adoc
@@ -18,14 +18,14 @@ We will start building a link:https://docs.docker.com/[Docker Image, window="_bl
 
 === Guides in this series
 
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[{simple-microservice-database-part1}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2[{simple-microservice-database-part2}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2[{simple-microservice-infinispan-part2}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[{simple-microservice-jms-part1}]
-* link:{{ site.baseurl }}/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2[{simple-microservice-jms-part2}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[{simple-microservice-database-part1}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2[{simple-microservice-database-part2}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2[{simple-microservice-infinispan-part2}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[{simple-microservice-jms-part1}]
+* link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2[{simple-microservice-jms-part2}]
 //* link:get-enterprise-ready[{get-enterprise-ready}]
 
 [[references]]


### PR DESCRIPTION
Follows up on https://github.com/wildfly/wildfly.org/pull/650

This just removes the `{{site.baseurl}}` because this has no configuration value at `_config.yml `, instead use direct absolute paths from root.