### PR TITLE
New "Cloud and Containers" category in Guides

### DIFF
--- a/_data/guides.yaml
+++ b/_data/guides.yaml
@@ -7,9 +7,6 @@ categories:
       - title: Getting Started with WildFly
         url: /get-started
         description: Build and run a Jakarta EE application with WildFly in a few minutes
-      - title: Java Microservices on Kubernetes with WildFly
-        url: /guides/get-started-microservices-on-kubernetes
-        description: Build and run Jakarta EE applications with WildFly on Kubernetes in a few minutes
   - category: Automation
     cat-id: automation
     guides:
@@ -19,6 +16,41 @@ categories:
       - title: Testing with Arquillian and JUnit 5
         url: /guides/testing-arquillian-junit5
         description: Learn how to write JUnit 5 tests using Arquillian for Jakarta EE based applications.
+  - category: Cloud / Containerization
+    cat-id: cloud-containerization
+    groups:
+      - title: Jakarta REST service
+        guides:
+          - description: Build the Container Image
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-part1
+          - description: Run the Container Image on Kubernetes
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-part2
+      - title: Jakarta REST service using a Database
+        guides:
+          - description: Build the Container Image
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1
+          - description: Run the Container Image on Kubernetes
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2
+      - title: Jakarta REST service using Infinispan
+        guides:
+          - description: Build the Container Image
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1
+          - description: Run the Container Image on Kubernetes
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2
+      - title: Jakarta REST service using a Message Broker
+        guides:
+          - description: Build the Container Image
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1
+          - description: Run the Container Image on Kubernetes
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2
+      - title: Jakarta REST service invoking another Jakarta REST service
+        guides:
+          - description: Build the Container Image
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-client-part1
+          - description: Run the Container Image on Kubernetes
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-client-part2
+          - description: Propagate Authentication and Authorization
+            url: /guides/get-started-microservices-on-kubernetes/simple-microservice-client-part3
   - category: Datasources
     cat-id: datasources
     guides:

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -22,7 +22,7 @@
             {% for guide in item.guides %}
               <div class="grid__item width-3-12 news-block-item">
                 <div class="post-title">
-                  <h4><a href="{{site.baseurl}}{{ guide.url }}">{{ guide.title}}</a></h4>
+                  <h4><a href="{{ site.baseurl }}{{ guide.url }}">{{ guide.title }}</a></h4>
                   <div class="description">{{ guide.description | markdownify }}</div>
                 </div>
               </div>

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -6,14 +6,28 @@
   <div class="grid-wrapper news-list-blocks">
     {% for item in site.data["guides"].categories %}
         <h2 class="grid__item width-12-12" id="{{ item.cat-id }}">{{ item.category }}</h3>
-        {% for guide in item.guides %}
-          <div class="grid__item width-3-12 news-block-item">
-            <div class="post-title">
-              <h4><a href="{{site.baseurl}}{{ guide.url }}">{{ guide.title}}</a></h4>
-              <div class="description">{{ guide.description | markdownify }}</div>
-            </div>
-          </div>
-        {% endfor %}
+        {% if item.groups %}
+            {% for group in item.groups %}
+                <div class="grid__item width-3-12 news-block-item">
+                    <div class="post-title">
+                        <h4>{{ group.title}}</h4>
+                        {% for guide in group.guides %}
+                        <div class="description"><a href="{{site.baseurl}}{{ guide.url }}">{{ guide.description}}</a></div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+        {% endif %}
+        {% if item.guides %}
+            {% for guide in item.guides %}
+              <div class="grid__item width-3-12 news-block-item">
+                <div class="post-title">
+                  <h4><a href="{{site.baseurl}}{{ guide.url }}">{{ guide.title}}</a></h4>
+                  <div class="description">{{ guide.description | markdownify }}</div>
+                </div>
+              </div>
+            {% endfor %}
+        {% endif %}
     {% endfor %}
   </div>
 </div>

--- a/_includes/index-guides.html
+++ b/_includes/index-guides.html
@@ -12,7 +12,7 @@
                     <div class="post-title">
                         <h4>{{ group.title}}</h4>
                         {% for guide in group.guides %}
-                        <div class="description"><a href="{{site.baseurl}}{{ guide.url }}">{{ guide.description}}</a></div>
+                        <div class="description"><a href="{{ site.baseurl }}{{ guide.url }}">{{ guide.description }}</a></div>
                         {% endfor %}
                     </div>
                 </div>


### PR DESCRIPTION
This PR moves the "WildFly mini Series" index up one level into the "Guides" page by creating a new "Docker and Kubernetes" category:

![image](https://github.com/user-attachments/assets/3b4ea78e-ef1c-456b-bd40-c2b99cb2060a)

"Draft" because this MR is based upon https://github.com/wildfly/wildfly.org/pull/671 and has to be re-based & merged afterwards