### PR TITLE
Add 'show_teaser' flag and 'teaser.html' include

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ forum_url: "https://groups.google.com/forum/#!forum/wildfly"
 # This should typically be 0. However, in some cases we might want a different index to be used. For example if a micro
 # is released, but we still want to advertise the newest minor or major.
 current_release_index: 0
+show_teaser: true
 
 # Build settings
 markdown: kramdown

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ forum_url: "https://groups.google.com/forum/#!forum/wildfly"
 # This should typically be 0. However, in some cases we might want a different index to be used. For example if a micro
 # is released, but we still want to advertise the newest minor or major.
 current_release_index: 0
-show_teaser: true
+show_teaser: false
 
 # Build settings
 markdown: kramdown

--- a/_includes/teaser.html
+++ b/_includes/teaser.html
@@ -1,0 +1,15 @@
+{% comment %} Example for a teaser *before* the WildFly Mini Conference
+<div class="grid__item width-12-12 home-section">
+  <h2>Save the date!</h2>
+  <h3>We're hosting our next conference on<br/>Wednesday, November 20</h3>
+  <h3><a href="{{site.baseurl}}/events/wmc_2024_11/">Wild<strong>Fly</strong> Mini Conference</a></h3>
+</div>
+{% endcomment %}
+
+{% comment %} Example for a teaser *after* the WildFly Mini Conference
+<div class="grid__item width-12-12 home-section">
+  <h2>Watch again and give feedback!</h2>
+  <h3>We’ve hosted our last conference on<br/>Wednesday, November 20</h3>
+  <h3><a href="{{site.baseurl}}/events/wmc_2024_11">Wild<strong>Fly</strong> Mini Conference</a></h3>
+</div>
+{% endcomment %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -28,11 +28,9 @@ layout: base
 
   </div>
 
-  <div class="grid__item width-12-12 home-section">
-    <h2>Watch again and give feedback!</h2>
-    <h3>We’ve hosted our last conference on Wednesday, November 20</h3>
-    <h3><a href="{{site.baseurl}}/conference/">Wild<strong>Fly</strong> Mini Conference</a></h3>
-  </div>
+  {% if site.show_teaser %}
+  {% include teaser.html %}
+  {% endif %}
 
   <div class="grid__item width-12-12 home-section">
     <div class="home-icons">


### PR DESCRIPTION
This PR redefines whether and how a teaser is visible on the home page: 

- The flag `show_teaser` in `_config.yml` controls the visibility of the teaser. 
- The include `_includes/teaser.html` defines the content of the teaser.  

For future teasers it's no longer necessary to edit the homepage, define the content in `_includes/teaser.html` and adjust `show_teaser` in `_config.yml`. 