### PR TITLE
Add Zulip chat links for the WMC 03/2025

### DIFF
--- a/_data/conference/202503.yaml
+++ b/_data/conference/202503.yaml
@@ -22,6 +22,9 @@ agenda:
       - "In this presentation, we will show how we can use JBang to prototype simple WildFly applications from a single Java source file. We start with a simple Web application and will integrate with a AI chat model in less than 15 minutes."
     speaker:
       - name: jmesnil
+    links:
+      - title: Chat
+        url: https://wildfly.zulipchat.com/#narrow/channel/492672-Mar-2025-Mini-Conference/topic/Thread.3A.20Quick.20prototyping.20with.20WildFly/with/507327271
   - title: Break
     start: "14:40"
     end: "14:55"
@@ -35,6 +38,9 @@ agenda:
     speaker:
       - name: rpelisse
         bio: "Romain Pelisse has been working at Red Hat for over a decade. He started as a runtimes consultant, building on expertise on JBoss EAP (WildFly), and moved to engineering where he became the lead of the Ansible runtimes initiative, focusing on providing the best integration possible between Red Hat middleware solutions and Ansible Automation Platform."
+    links:
+      - title: Chat
+        url: https://wildfly.zulipchat.com/#narrow/channel/492672-Mar-2025-Mini-Conference/topic/Thread.3A.20WildFly.20Day.20One.20operations.20with.20Ansible.20Automation/with/507327383
   - title: "Everything about Jakarta EE TCKs in twenty minutes"
     start: "15:40"
     end: "16:00"
@@ -44,6 +50,9 @@ agenda:
     speaker:
       - name: scottmarlow
         bio: "Scott is a long time WildFly/JBoss developer (around 19 years), contributes to Jakarta EE and also is one of the Jakarta EE Platform TCK leads."
+    links:
+      - title: Chat
+        url: https://wildfly.zulipchat.com/#narrow/channel/492672-Mar-2025-Mini-Conference/topic/Thread.3A.20Everything.20about.20Jakarta.20EE.20TCKs.20in.20twenty.20minutes/with/507327634
   - title: "Break"
     start: "16:00"
     end: "16:30"
@@ -57,6 +66,9 @@ agenda:
     speaker:
       - name: bstansberry
         bio: "Brian Stansberry is the lead of the WildFly application server project and the principal architect of Red Hat's JBoss Enterprise Application Platform."
+    links:
+      - title: Chat
+        url: https://wildfly.zulipchat.com/#narrow/channel/492672-Mar-2025-Mini-Conference/topic/Thread.3A.20WildFly.20in.20a.20Vendor-Neutral.20Foundation/with/507327701
   - title: "WildFly AI Feature Pack: Deploying an MCP server"
     start: "17:00"
     end: "17:45"
@@ -69,6 +81,9 @@ agenda:
         bio: "Emmanuel works at Red Hat on the messaging subsystem and on the developer experience."
       - name: jfdenise
         bio: "Jean-François Denise is a principal software engineer at Red Hat. He is involved in WildFly provisioning and tooling (WildFly CLI, WildFly Bootable JAR, Openshift images, WildFly Glow)."
+    links:
+      - title: Chat
+        url: https://wildfly.zulipchat.com/#narrow/channel/492672-Mar-2025-Mini-Conference/topic/Thread.3A.20WildFly.20AI.20Feature.20Pack.3A.20deploying.20an.20.20MCP.20server/with/507327790
   - title: "Feedback and closing ceremony"
     start: "17:45"
     end: "18:00"


### PR DESCRIPTION
This PR adds the links to the topics in the WildFly Zulip chat on the WMC 03/2025 agenda page. 