### PR TITLE
Add the download information for WildFly 37 Beta

### DIFF
--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -1,3 +1,65 @@
+- version: 37.0.0.Beta1
+  version_shortname: 37 Beta1
+  date: 2025-06-26
+  qualifier: Beta
+  gpg_key: ed25519/E85C11F6
+  link:
+    - name: WildFly Distribution
+      items:
+        - format: zip
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.zip
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.zip.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.zip.asc
+        - format: tgz
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.tar.gz
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.tar.gz.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1.tar.gz.asc
+    - name: WildFly Preview Distribution
+      items:
+        - format: zip
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.zip
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.zip.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.zip.asc
+        - format: tgz
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.tar.gz
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.tar.gz.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-preview-37.0.0.Beta1.tar.gz.asc
+    - name: Application Server Source Code
+      licence: AL
+      items:
+        - format: zip
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.zip
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.zip.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.zip.asc
+        - format: tgz
+          url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.tar.gz
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.tar.gz.sha1
+          signature: GPG
+          signature_url: https://github.com/wildfly/wildfly/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-src.tar.gz.asc
+    - name: Quick Start Source Code
+      licence: AL
+      items:
+        - format: Git Tag
+          url: https://github.com/wildfly/quickstart/tree/37.0.0.Beta1
+        - format: zip
+          url: https://github.com/wildfly/quickstart/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-quickstarts.zip
+          checksum: SHA-1
+          checksum_url: https://github.com/wildfly/quickstart/releases/download/37.0.0.Beta1/wildfly-37.0.0.Beta1-quickstarts.zip.sha1
+    - name: Release Notes
+      items:
+        - format: Notes
+          url: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12449162
 - version: 36.0.1.Final
   version_shortname: 36.0.1.Final
   date: 2025-05-15
@@ -96,55 +158,6 @@
       items:
         - format: Notes
           url: https://wildfly.org/news/2025/04/10/WildFly36Released/
-- version: 36.0.0.Beta1
-  version_shortname: 36 Beta1
-  date: 2025-03-27
-  qualifier: Beta
-  link:
-    - name: WildFly Distribution
-      items:
-        - format: zip
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1.zip
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1.zip.sha1
-        - format: tgz
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1.tar.gz
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1.tar.gz.sha1
-    - name: WildFly Preview Distribution
-      items:
-        - format: zip
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-preview-36.0.0.Beta1.zip
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-preview-36.0.0.Beta1.zip.sha1
-        - format: tgz
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-preview-36.0.0.Beta1.tar.gz
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-preview-36.0.0.Beta1.tar.gz.sha1
-    - name: Application Server Source Code
-      licence: AL
-      items:
-        - format: zip
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-src.zip
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-src.zip.sha1
-        - format: tgz
-          url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-src.tar.gz
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/wildfly/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-src.tar.gz.sha1
-    - name: Quick Start Source Code
-      licence: AL
-      items:
-        - format: Git Tag
-          url: https://github.com/wildfly/quickstart/tree/36.0.0.Beta1
-        - format: zip
-          url: https://github.com/wildfly/quickstart/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-quickstarts.zip
-          checksum: SHA-1
-          checksum_url: https://github.com/wildfly/quickstart/releases/download/36.0.0.Beta1/wildfly-36.0.0.Beta1-quickstarts.zip.sha1
-    - name: Release Notes
-      items:
-        - format: Notes
-          url: https://wildfly.org/news/2025/03/27/WildFly36Beta-released
 - version: 35.0.1.Final
   version_shortname: 35.0.1.Final
   date: 2025-02-06

--- a/_data/releases.yaml
+++ b/_data/releases.yaml
@@ -59,7 +59,7 @@
     - name: Release Notes
       items:
         - format: Notes
-          url: https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12449162
+          url: https://wildfly.org/news/2025/06/26/WildFly37Beta-released/
 - version: 36.0.1.Final
   version_shortname: 36.0.1.Final
   date: 2025-05-15

--- a/_layouts/contributors-pgp.html
+++ b/_layouts/contributors-pgp.html
@@ -32,7 +32,7 @@ layout: base
                 <table>
                     {% for signing in contributor.signing %}
                     <tr class="separator">
-                        <td class="contributor-label">Public Key Id</td>
+                        <td class="contributor-label" id="{{ signing.pgp.id }}">Public Key Id</td>
                         <td class="copy-text">{{ signing.pgp.id }}</td>
                     </tr>
                     <tr>

--- a/_layouts/downloads.html
+++ b/_layouts/downloads.html
@@ -10,7 +10,7 @@ layout: base
       <div class="download-ctas">
         <a href="https://github.com/wildfly/wildfly/releases/download/{{latestRelease.version}}/wildfly-{{latestRelease.version}}.zip" class="button-cta">Download the zip</a>
         <a href="https://github.com/wildfly/wildfly/releases/download/{{latestRelease.version}}/wildfly-{{latestRelease.version}}.tar.gz" class="button-cta">Download the tgz</a>
-      </div> 
+      </div>
       <div class="page-eap">
         <h4>The technology behind Wild<strong>Fly</strong> is also available in <a href="https://www.redhat.com/en/technologies/jboss-middleware/application-platform" target="_blank">JBoss Enterprise Application Platform</a>. JBoss EAP is a hardened enterprise subscription with Red Hat’s world-class support, long multi-year maintenance cycles, and exclusive content. <a href="https://developers.redhat.com/register" target="_blank">Sign-up with Red Hat</a> to download a no-cost 1-year development license.</h4>
         <a href="https://developers.redhat.com/products/eap/download/" class="button-cta secondary" target="_blank">Download Red Hat JBoss EAP</a>
@@ -36,11 +36,19 @@ layout: base
                   <!--<td class="licence">{{releaseItem.licence}}</td>-->
                   <td class="links">
                     {% for releaseFormat in releaseItem.items %}
-                    <a href="{{releaseFormat.url}}">{{releaseFormat.format}}</a>{% if releaseFormat.checksum %} | <a href="{{releaseFormat.checksum_url}}">{{releaseFormat.checksum}}</a>{% endif %}<br/>
+                    <a href="{{releaseFormat.url}}">{{releaseFormat.format}}</a>{% if releaseFormat.checksum %} | <a href="{{releaseFormat.checksum_url}}">{{releaseFormat.checksum}}</a>{% endif %}{% if releaseFormat.signature %} | <a href="{{releaseFormat.signature_url}}">{{releaseFormat.signature}}</a>{% endif %}<br/>
                     {% endfor %}
                   </td>
                 </tr>
                 {% endfor %}
+                {% if versionId.gpg_key %}
+                <tr>
+                  <td class="description">Signed Using GPG Key</td>
+                  <td class="links">
+                    <a href="{{site.baseurl}}/contributors/pgp#{{versionId.gpg_key}}">{{versionId.gpg_key}}</a>
+                  </td>
+                </tr>
+                {% endif %}
               </table>
             </div>
           </div>

--- a/_posts/2025-06-26-WildFly37Beta-released.adoc
+++ b/_posts/2025-06-26-WildFly37Beta-released.adoc
@@ -1,0 +1,90 @@
+---
+layout: post
+title:  "New WildFly 37 Beta release"
+date:   2025-06-26
+tags:   announcement release
+author: darranl
+description: WildFly 37 Beta is now available for download.
+---
+
+We're excited to announce the release of WildFly 37.0.0.Beta1! This beta release, available for download from https://wildfly.org/downloads, includes new features and several enhancements, alongside numerous component upgrades.
+
+== Key Highlights in this Beta Release:
+
+=== New Features:
+
+* Artemis commit-interval attribute for scaledown: WildFly 37 Beta 1 exposes the Artemis commit-interval attribute for scaledown.
+* The /core-service=platform-mbean resources have been evolved to expose new platform MXBeans, attributes and operations.
+
+=== Enhancements:
+
+* The tasks-jsf quickstart now uses Glow.
+* GPG detached signatures are now included with uploads at release time.
+
+The following commands demonstrate how to verify the GPG signature of the WildFly distribution:
+
+[source,console]
+----
+$ gpg --keyserver keyserver.ubuntu.com --recv-keys E85C11F6
+$ gpg --verify wildfly-37.0.0.Beta1-src.tar.gz.asc wildfly-37.0.0.Beta1-src.tar.gz
+gpg: Signature made Wed 25 Jun 2025 14:33:44 BST
+gpg:                using EDDSA key 245404A11575A55D6A41107E2D52D4ACE85C11F6
+gpg: Good signature from "Darran Andrew Lofthouse <darran.lofthouse@jboss.com>" [unknown]
+gpg:                 aka "Darran Andrew Lofthouse <darran.lofthouse@redhat.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 2454 04A1 1575 A55D 6A41  107E 2D52 D4AC E85C 11F6
+----
+
+Contributors to WildFly publish their GPG keys on the https://wildfly.org/contributors/pgp[Contributor PGP Information], which
+includes the fingerprint to aid verification.
+
+=== Component Upgrades:
+
+This release includes a significant number of component upgrades, ensuring WildFly remains current with the latest technologies and provides improved performance and security. Some notable upgrades include:
+
+* Vert.x to 4.5.15.
+* Hibernate ORM to 6.6.18.Final (and 7.0.2.Final for WildFly Preview).
+* Micrometer to 1.15.0.
+* EclipseLink to 4.0.6.
+* SmallRye Fault Tolerance to 6.9.1.
+* Apache Santuario XML Security for Java to 3.0.6.
+* JBoss Universe Producers to 1.3.14.
+* JBoss Metadata to 16.1.0.Final.
+* Netty to 4.1.122.Final.
+* Velocity Engine to 2.4.1.
+* WildFly Clustering to 7.0.5.Final.
+* Infinispan to 15.2.4.Final.
+* JGroups to 5.4.
+* Apache Artemis to 2.41.0.
+* WildFly Core to 29.0.0.Beta6.
+* HAL to 3.7.12.Final.
+* Byteman to 4.0.25.
+* JBossWS-CXF to 7.3.3.Final.
+* Narayana to 7.2.2.Final.
+* zstd-jni to 1.5.7-3.
+* WildFly Licenses Plugin to 2.4.2.Final.
+* FasterXML Jackson to 2.18.4.
+* SmallRye Common to 2.12.0.
+* Hibernate Search to 8.0.0.Final (in WildFly preview).
+* Weld to 5.1.6.Final and 6.0.3.Final.
+* Hibernate Validator to 9.0.1.Final (in WildFly preview).
+* Expressly to 6.0.0 (in WildFly preview).
+* Apache CXF to 4.0.8.
+* Commons-Beanutils to 1.11.0, which resolves CVE-2025-48734.
+* WildFly Channel Maven Plugin to 1.0.25.
+* WildFly HTTP Client to 2.1.1.Final.
+* Narayana LRA to 1.0.1.Final.
+* Arquillian BOM to 1.9.5.Final.
+* Arquillian Testcontainers to 1.0.0.Alpha4.
+* Caffeine to 3.2.1.
+* Apache Kafka to 3.9.1.
+* SmallRye OpenAPI to 4.0.11.
+* Nimbus Jose JWT to 10.3.
+* Artemis WildFly Integration to 2.0.4.Final.
+* MVC Krazo integration to 2.0.0.Final.
+* OWASP Dependency Check Plugin to 12.1.3.
+
+For a complete list of bug fixes, tasks, sub-tasks, and other changes, please refer to the link:https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12313721&version=12449162[full release notes]. We encourage the community to test this beta release and provide feedback to help us stabilize WildFly 37.
+
+


### PR DESCRIPTION
Also include links to the .asc files to enable verification of the signatures.

Finally publish the ID of the key used to sign the release as different people will use their own GPG key when releasing.