### PR TITLE
Update build to Roq 1.8.1

### DIFF
--- a/content/guides/application-logging.adoc
+++ b/content/guides/application-logging.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Configuring Logging for your Application
 :summary: Learn how to use logging in your application and configure WildFly to display them
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: ../../templates/
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
@@ -12,7 +12,7 @@ layout: guide
 In this guide, you will learn how to use logging in your application and configure WildFly to
 display the logs at the level you want.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
 WildFly supports all major logging facades. These include:
 
@@ -58,7 +58,6 @@ You need to add it to the `<dependencies>` section of the `pom.xml`:
 
 As an example, you can update the `GettingStartedService.java` file to add logging to the application at different levels:
 
-{|
 [source,java]
 ----
 package org.wildfly.examples;
@@ -80,7 +79,6 @@ public class GettingStartedService {
     }
 }
 ----
-|}
 You added a `log` Logger that can log messages with a name corresponding to the class `org.wildfly.examples.GettingStartedService`.
 You also added two logging calls, one at the `TRACE` level and the other one at the `INFO` level.
 
@@ -131,7 +129,7 @@ Copy the XML snippet:
 <!-- Execute the script in offline mode -->
 <offline>true</offline>
 <scripts>
-    <script>$\{project.build.scriptSourceDirectory}/configuration.cli</script>
+    <script>${project.build.scriptSourceDirectory}/configuration.cli</script>
 </scripts>
 ----
 
@@ -142,7 +140,7 @@ And add it to the `<configuration>` section of the `wildfly-maven-plugin`:
 <plugin>
     <groupId>org.wildfly.plugins</groupId>
     <artifactId>wildfly-maven-plugin</artifactId>
-    <version>$\{version.wildfly.maven.plugin}</version>
+    <version>${version.wildfly.maven.plugin}</version>
     <configuration>
         <!-- copy the XML snippet here -->
     </configuration>
@@ -173,10 +171,10 @@ $ mvn clean verify
 
 == What's next?
 
-WildFly provides extensive logging configuration. You can learn more by reading WildFly's https://docs.wildfly.org/\{wildfly-version}/Admin_Guide.html#Logging[Logging Subsystem Configuration Guide] and its https://docs.wildfly.org/\{wildfly-version}/wildscribe/subsystem/logging/[model reference].
+WildFly provides extensive logging configuration. You can learn more by reading WildFly's https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Logging[Logging Subsystem Configuration Guide] and its https://docs.wildfly.org/{wildfly-version}/wildscribe/subsystem/logging/[model reference].
 
 [[references]]
 == References
 
-* https://docs.wildfly.org/\{wildfly-version}/Admin_Guide.html#Logging[Logging Subsystem Configuration Guide]
-* https://docs.wildfly.org/\{wildfly-version}/wildscribe/subsystem/logging/[Logging Subsystem Model Reference]
+* https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Logging[Logging Subsystem Configuration Guide]
+* https://docs.wildfly.org/{wildfly-version}/wildscribe/subsystem/logging/[Logging Subsystem Model Reference]

--- a/content/guides/automate-with-ansible.adoc
+++ b/content/guides/automate-with-ansible.adoc
@@ -3,15 +3,15 @@ layout: guide
 ---
 = Deploying WildFly using Ansible
 :summary: Learn how to automate WildFly deployments with Ansible
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 20
 
 In this brief guide, we’ll set up and run three instances of WildFly on the same machine (localhost). Together they will form a cluster. It’s a rather classic setup, where the appservers need to synchronize the content of their application’s sessions to ensure fail over if one of the instances fails. This configuration guarantees that, if one instance fails while processing a request, another one can pick up the work without any data loss. Note that we’ll use a multicast to discover the members of the cluster and ensure that the cluster’s formation is fully automated and dynamic.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
 == Install Ansible and its collection for WildFly
 
@@ -72,7 +72,6 @@ There are essentially two steps to set up the WildFly cluster:
 
 Here is the playbook we'll use to deploy our clusters. Its content is relatively self-explanitory, at least if you are somewhat familiar with the Ansible syntax.
 
-{|
 [source, yml]
 ----
 - name: "WildFly installation and configuration"
@@ -124,7 +123,6 @@ Here is the playbook we'll use to deploy our clusters. Its content is relatively
       loop_control:
         loop_var: port
 ----
-|}
 In short, this playbook uses the Ansible collection for WildFly to, first, install the appserver by using the wildfly_install role. This will download all the artifacts, create the required system groups and users, install dependency (unzip) and so on. At the end of its execution, all the tidbits required to run WildFly on the target host are installed, but the server is not yet running. That is what's happening in the next step.
 
 In the tasks section of the playbook, we then call on another role provided by the collection: wildfly_systemd. This role will take care of integrating WildFly, as a regular system service, into the service manager. Here, we use a loop to ensure that we create not one, but three different services. Each one will have the same configuration (standalone-ha.xml) but runs on different ports, using a different set of directories to store its data.
@@ -445,7 +443,6 @@ Now, our three WildFly servers are running, but the cluster has yet to form. Ind
 
 In our case, we will use the jboss_cli.yml task file, which encapsulates the running of JBoss command-line interface (CLI) commands:
 
-{|
 [source, yaml]
 ----
 …
@@ -468,7 +465,6 @@ In our case, we will use the jboss_cli.yml task file, which encapsulates the run
           - 10090
           - 10190
 ----
-|}
 
 Now, we will once again execute our playbook so the web application is deployed on all instances. Once the automation completes successfully, the deployment will trigger the formation of the cluster.
 

--- a/content/guides/database-integrating-with-postgresql.adoc
+++ b/content/guides/database-integrating-with-postgresql.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Integrating with a PostgreSQL database
 :summary: Learn how to configure a datasource to connect a PostgreSQL database
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 20
 :postgre-sql-user: postgres
 :postgre-sql-password: admin
@@ -16,7 +16,7 @@ layout: guide
 
 In this guide, you will learn how to configure WildFly to connect to a PostgreSQL database. You will create a simple Book Store API application to manage books stored in the database using https://jakarta.ee/specifications/restful-ws/[Jakarta RESTful Web Services (Jakarta REST), window=_blank].
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
 * Docker or any Open Container Initiative engine installed. This guide uses https://podman.io/[Podman, window=_blank].
 
@@ -28,7 +28,6 @@ We will use PostgreSQL as the database server in its containerized version: see 
 
 Start PostgreSQL database in a container with:
 
-{|
 [source,bash,subs="normal"]
 ----
 podman run --rm --name bookstore \
@@ -38,7 +37,6 @@ podman run --rm --name bookstore \
   -e POSTGRES_DB={postgre-sql-database} \
   {postgre-docker-image}
 ----
-|}
 
 NOTE: we started the container with the `--rm` flag so it can be disposed of automatically when we stop it.
 
@@ -104,7 +102,6 @@ In addition to the Galleon Layers to configure the datasource and install the dr
 
 Replace the current `wildfly-maven-plugin` configuration in the `pom.xml` file provided by the getting started guide with the following one:
 
-{|
 [source,xml]
 ----
 <plugin>
@@ -127,7 +124,6 @@ Replace the current `wildfly-maven-plugin` configuration in the `pom.xml` file p
     </executions>
 </plugin>
 ----
-|}
 In the above configuration, behind the scenes the `wildfly-maven-plugin` is using https://docs.wildfly.org/wildfly-glow/[WildFly Glow, window=_blank] to discover automatically the required Galleon Layers for our application. The `discover-provisioning-info` configuration tells the plugin to discover the required layers by inspecting our application code. By using the `postgresql:default` addon, we are specifying we want to use a PostgreSQL database, and we want to configure it as the default datasource for the server.
 
 === persistence.xml
@@ -164,7 +160,7 @@ import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/api")
-public class BookStoreApplication extends Application \{
+public class BookStoreApplication extends Application {
 }
 ----
 
@@ -173,7 +169,6 @@ The `Book` entity represents a book record in the database.
 
 Create a new class `Book` in the `src/main/java/org/wildfly/examples/books` directory with the following content:
 
-{|
 [source,java]
 ----
 package org.wildfly.examples.books;
@@ -283,14 +278,12 @@ public class Book {
     }
 }
 ----
-|}
 
 === BookResource
 The `BookResource` is the web service that exposes the book records as JSON objects.
 
 Create a new class `BookResource` in the `src/main/java/org/wildfly/examples/books` directory with the following content:
 
-{|
 [source,java]
 ----
 package org.wildfly.examples.books;
@@ -400,7 +393,6 @@ public class BookResource {
     }
 }
 ----
-|}
 
 == Start the application
 
@@ -453,7 +445,6 @@ postgresql-default-datasource environment variables:
 
 Now create the required *environment variables* used by WildFly to connect to the PostgreSQL database and start the server:
 
-{|
 [source,bash,subs="normal"]
 ----
 export POSTGRESQL_USER={postgre-sql-user}
@@ -464,7 +455,6 @@ export POSTGRESQL_DATABASE={postgre-sql-database}
 ...
 11:34:49,242 INFO  [org.jboss.as] (Controller Boot Thread) WFLYSRV0025: WildFly Full 32.0.1.Final (WildFly Core 24.0.1.Final) started in 2118ms - Started 295 of 366 services (139 services are lazy, passive or on-demand) - Server configuration file in use: standalone.xml
 ----
-|}
 
 == Check the application
 
@@ -473,7 +463,6 @@ We have our application running at http://localhost:8080/. Let's now interact wi
 === Create a book
 To create a new book, execute a POST request to the `/api/books` endpoint with the book information:
 
-{|
 [source,bash]
 ----
 $ curl -v -X POST http://localhost:8080/api/books -H "Content-Type: application/json" -d '
@@ -484,7 +473,6 @@ $ curl -v -X POST http://localhost:8080/api/books -H "Content-Type: application/
 "title": "From the Earth to the Moon"
 }'
 ----
-|}
 
 If you inspect the response, you will see the URL of the newly created book gets returned under the location header:
 
@@ -495,7 +483,6 @@ Location: http://localhost:8080/api/books/1
 
 You can use the location to check the book you have just created:
 
-{|
 [source,bash]
 ----
 $ curl http://localhost:8080/api/books/1
@@ -510,7 +497,6 @@ $ curl http://localhost:8080/api/books/1
   "title": "From the Earth to the Moon"
 }
 ----
-|}
 
 === Read all the books
 To list all the books, execute a GET request to the `/api/books` endpoint:
@@ -522,7 +508,6 @@ $ curl http://localhost:8080/api/books
 
 It will return the list of books of our database:
 
-{|
 [source,json]
 ----
 [
@@ -535,12 +520,10 @@ It will return the list of books of our database:
   }
 ]
 ----
-|}
 
 === Update a book
-To update a book, execute a PUT request to the `/api/books/\{id}` endpoint with the book information you want. For example to change the price of the recent book we have recently created, execute the following:
+To update a book, execute a PUT request to the `/api/books/{id}` endpoint with the book information you want. For example to change the price of the recent book we have recently created, execute the following:
 
-{|
 [source,bash]
 ----
 $ curl -X PUT http://localhost:8080/api/books/1 -H "Content-Type: application/json" -d '
@@ -551,10 +534,9 @@ $ curl -X PUT http://localhost:8080/api/books/1 -H "Content-Type: application/js
 "title": "From the Earth to the Moon"
 }'
 ----
-|}
 
 === Delete a book
-To delete a book, execute a DELETE request to the `/api/books/\{id}` endpoint with the book id you want to delete. For example, to delete the book we have recently created:
+To delete a book, execute a DELETE request to the `/api/books/{id}` endpoint with the book id you want to delete. For example, to delete the book we have recently created:
 
 [source,bash]
 ----
@@ -588,7 +570,6 @@ Add the following dependency to the `pom.xml` file:
 
 Create a new class `BookResourceIT` in the `src/test/java/org/wildfly/examples/books` directory with the following content:
 
-{|
 [source,java]
 ----
 package org.wildfly.examples.books;
@@ -738,7 +719,6 @@ export POSTGRESQL_DATABASE={postgre-sql-database}
 
 mvn clean verify
 ----
-|}
 
 In this guide we have reused the same database instance for running the application and for the test cases. If you want to use a different instance for test cases, you have to adapt the values of the environment variables accordingly.
 

--- a/content/guides/get-started-microservices-on-kubernetes.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes.adoc
@@ -3,10 +3,9 @@ layout: getstarted
 title: Java Microservices on Kubernetes with WildFly
 ---
 :includedir: ./get-started-microservices-on-kubernetes/_includes
-{#include partials/guides/titles.adoc /}
+include::../../templates/partials/guides/titles.adoc[]
 :page-liquid:
 
-{|
 == Build Java Microservices with WildFly and run them on link:https://kubernetes.io/[Kubernetes, window="_blank"].
 
 === Intro
@@ -41,5 +40,3 @@ We will start building a link:https://docs.docker.com/[Docker Image, window="_bl
 == References
 
 * https://microprofile.io/specifications/microprofile-config/[Eclipse MicroProfile Config, window="_blank"]
-
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/get-enterprise-ready.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/get-enterprise-ready.adoc
@@ -2,8 +2,8 @@
 layout: guide-getting-started
 ---
 
-= \{get-enterprise-ready}
-{#include partials/guides/titles.adoc /}
+= {get-enterprise-ready}
+include::../../../templates/partials/guides/titles.adoc[]
 
 
 Back to Guides

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part1.adoc
@@ -1,17 +1,16 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-client-part1}
+= {simple-microservice-client-part1}
 :summary: Invoke one microservice from another
-:includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
-{#include partials/guides/constants.adoc /}
+:includedir: /templates
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
+include::../../../templates/partials/guides/constants.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
 
-{|
 In this guide, you will learn HOW-TO invoke one microservice from another;
 
 [[prerequisites]]
@@ -296,4 +295,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-client-
 * Source code for this guide:
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-client
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-server
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part2.adoc
@@ -1,17 +1,16 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-client-part2}
+= {simple-microservice-client-part2}
 :summary: Invoke one microservice from another on Kubernetes
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
+include::../../../templates/partials/guides/constants.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
 
-{|
 In this guide, you will learn HOW-TO run the Docker Images you built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part1[{simple-microservice-client-part1}] on Kubernetes.
 
 [[prerequisites]]
@@ -299,4 +298,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-client-
 * Source code for this guide:
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-client
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-server
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part3.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-client-part3.adoc
@@ -1,17 +1,16 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-client-part3}
+= {simple-microservice-client-part3}
 :summary: Invoke one microservice from another on Kubernetes propagating users authentication
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
+include::../../../templates/partials/guides/constants.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
 
-{|
 In this guide, you will learn HOW-TO propagate user authentication and authorization data between two microservices;
 
 [[prerequisites]]
@@ -757,4 +756,3 @@ Hello ddd Subject:aaef43ee-4005-4d2d-a5f0-0e0d11a1f831 Issuer: http://192.168.39
 * Source code for this guide:
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-client-secured
 ** {source-code-git-repository}/simple-microservice-rest-client/simple-microservice-server-secured
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-database-part1}
+= {simple-microservice-database-part1}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}] and add Database connectivity.
+In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}] and add Database connectivity.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Database
 
 === PostgreSQL
@@ -375,4 +374,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-databas
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part2.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-database-part2}
+= {simple-microservice-database-part2}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[\{simple-microservice-database-part1}] on Kubernetes.
+In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[{simple-microservice-database-part1}] on Kubernetes.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[\{simple-microservice-database-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-database-part1[{simple-microservice-database-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Database
 
 === PostgreSQL
@@ -297,4 +296,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinis
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-infinispan-part1}
+= {simple-microservice-infinispan-part1}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}] and use a remote link:https://infinispan.org/[Infinispan Server, window="_blank"] to cache HTTP Session data.
+In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}] and use a remote link:https://infinispan.org/[Infinispan Server, window="_blank"] to cache HTTP Session data.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Infinispan Server
 
 Infinispan is the most common solution used with WildFly when you want to cache some data outside WildFly.
@@ -267,4 +266,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinis
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part2.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-infinispan-part2}
+= {simple-microservice-infinispan-part2}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[\{simple-microservice-infinispan-part1}] on Kubernetes.
+In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}] on Kubernetes.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[\{simple-microservice-infinispan-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-infinispan-part1[{simple-microservice-infinispan-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Infinispan
 
 We basically will repeat everything we did in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}] but, before, we will deploy Infinispan on Kubernetes.
@@ -275,4 +274,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-par
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-jms-part1}
+= {simple-microservice-jms-part1}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}] and add an external Message Broker connectivity.
+In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}] and add an external Message Broker connectivity.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == External Message Broker
 
 === Apache Artemis
@@ -293,4 +292,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-par
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part2.adoc
@@ -1,25 +1,24 @@
 ---
 layout: guide-getting-started
 ---
-= \{simple-microservice-jms-part2}
+= {simple-microservice-jms-part2}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[\{simple-microservice-jms-part1}] on Kubernetes.
+In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[{simple-microservice-jms-part1}] on Kubernetes.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[\{simple-microservice-jms-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-jms-part1[{simple-microservice-jms-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Apache Artemis
 
 === Apache Artemis deployment
@@ -220,4 +219,3 @@ Sent Hello World to getting-started-queue
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1.adoc
@@ -2,25 +2,24 @@
 layout: guide-getting-started
 ---
 
-= \{simple-microservice-llm-part1}
+= {simple-microservice-llm-part1}
 :summary: Java Microservice using WildFly that invokes an LLM
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}] and consume an external LLM APIs through LangChain4J.
+In this guide, we will extend the example created in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}] and consume an external LLM APIs through LangChain4J.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == LLM
 
 You can use any LLM supported by link:https://docs.langchain4j.dev/integrations/language-models[LangChain4J, window="_blank"]; in this guide we will use model `{ollama-llm}` and run it using the link:https://ollama.com/blog/ollama-is-now-available-as-an-official-docker-image[Ollama Docker Image, window="_blank"];
@@ -291,4 +290,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-par
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part2.adoc
@@ -2,25 +2,24 @@
 layout: guide-getting-started
 ---
 
-= \{simple-microservice-llm-part2}
+= {simple-microservice-llm-part2}
 :summary: Java Microservice using WildFly on Kubernetes that invokes an LLM
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
-In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1[\{simple-microservice-llm-part1}] on Kubernetes.
+In this guide, you will learn HOW-TO run the Docker Image we built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1[{simple-microservice-llm-part1}] on Kubernetes.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1[\{simple-microservice-llm-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-llm-part1[{simple-microservice-llm-part1}]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == LLM
 
 We basically will repeat everything we did in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}] with a few changes but, before that, we will deploy link:https://ollama.com/library/smollm2[`{ollama-llm}`, window="_blank"] on Kubernetes using the Ollama container.
@@ -266,4 +265,3 @@ NOTE: if you get *"dev.langchain4j.exception.HttpException: {"error":"model requ
 Back to Guides
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-part1.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-part1.adoc
@@ -2,24 +2,23 @@
 layout: guide-getting-started
 ---
 
-= \{simple-microservice-part1}
+= {simple-microservice-part1}
 :summary: Java Microservice using WildFly
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 :prerequisites-time: 10
 
 In this guide, you will learn how to create and run a link:https://docs.docker.com/guides/docker-concepts/the-basics/what-is-an-image/[Docker Image, window="_blank"] containing a link:https://jakarta.ee/specifications/restful-ws/[Jakarta REST service, window="_blank"] implemented using WildFly.
 
-In the following guide link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[\{simple-microservice-part2}], you will see how to run the same link:https://docs.docker.com/guides/docker-concepts/the-basics/what-is-an-image/[Docker Image, window="_blank"] on link:https://kubernetes.io/[Kubernetes];
+In the following guide link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{simple-microservice-part2}], you will see how to run the same link:https://docs.docker.com/guides/docker-concepts/the-basics/what-is-an-image/[Docker Image, window="_blank"] on link:https://kubernetes.io/[Kubernetes];
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../../templates/partials/guides/prerequisites.adoc[]
 
 * Install link:https://www.docker.com/[Docker, window="_blank"] or link:https://podman.io/[Podman, window="_blank"]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Maven Project
 
 Create a simple Jakarta EE application Maven Project containing a link:https://jakarta.ee/specifications/restful-ws/[Jakarta REST service, window="_blank"] using the `org.wildfly.archetype:wildfly-getting-started-archetype` archetype:
@@ -243,4 +242,3 @@ link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part2[{
 * link:https://www.wildfly.org/news/2025/01/27/testing-on-docker-with-cube/["Testing WildFly applications on Docker with Arquillian Cube", window="_blank"]
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/get-started-microservices-on-kubernetes/simple-microservice-part2.adoc
+++ b/content/guides/get-started-microservices-on-kubernetes/simple-microservice-part2.adoc
@@ -2,28 +2,27 @@
 layout: guide-getting-started
 ---
 
-= \{simple-microservice-part2}
+= {simple-microservice-part2}
 :summary: Java Microservice using WildFly on Kubernetes
 :includedir: ../_includes
-{#include partials/guides/attributes.adoc /}
-{#include partials/guides/titles.adoc /}
+include::../../../templates/partials/guides/attributes.adoc[]
+include::../../../templates/partials/guides/titles.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
 
-In this guide, you will learn HOW-TO run the Docker Image you built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}] on Kubernetes.
+In this guide, you will learn HOW-TO run the Docker Image you built in link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}] on Kubernetes.
 
 [[prerequisites]]
 == Prerequisites
 
 To complete this guide, you need:
 
-* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[\{simple-microservice-part1}]
+* Complete link:/guides/get-started-microservices-on-kubernetes/simple-microservice-part1[{simple-microservice-part1}]
 * A link:https://kubernetes.io[Kubernetes, window="_blank"] cluster: throughout this mini-series, we will use link:https://minikube.sigs.k8s.io[Minikube, window="_blank"]
 
-{#include partials/guides/constants.adoc /}
+include::../../../templates/partials/guides/constants.adoc[]
 
-{|
 == Image Registry
 
 To make the `{my-jaxrs-app-docker-image-name}:latest` Docker Image available to Kubernetes, you need to push it to some Image Registry that is accessible by the Kubernetes cluster you want to use.
@@ -163,4 +162,3 @@ Hello 'pippo'.
 * Source code for this guide: {source-code-git-repository}/simple-microservice
 
 < link:/guides/get-started-microservices-on-kubernetes[Back to Getting Started with WildFly micro-services on Kubernetes]
-|}

--- a/content/guides/messaging-clustering.adoc
+++ b/content/guides/messaging-clustering.adoc
@@ -3,13 +3,12 @@ layout: guide
 ---
 = Configuring Clustered Messaging in WildFly
 :summary: Learn how to configure WildFly with an ActiveMQ Artemis Cluster, Server-Side Message and Client Load Balancing.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 15
 
-{|
 In this guide, you will learn how to configure WildFly servers with an embedded ActiveMQ Artemis broker in a messaging cluster,
 enabling server-side message and client load balancing. It will demonstrate how to configure deployments, such as MDBs,
 EJBs, or Servlets, as well as external JMS clients, to load balance connections across all servers in the cluster.
@@ -176,4 +175,3 @@ refer to link:messaging-high-availability[Configure WildFly with a Messaging (Ac
 
 * https://activemq.apache.org/components/artemis/documentation/latest/clusters.html#overview[Apache ActiveMQ Artemis Documentation - Clusters]
 * https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/7.4/html-single/configuring_messaging/index#clusters_overview[EAP 7.4 Messaging Clusters Overview].
-|}

--- a/content/guides/messaging-high-availability-openshift.adoc
+++ b/content/guides/messaging-high-availability-openshift.adoc
@@ -3,22 +3,21 @@ layout: guide
 ---
 = Deploying High-Availability Messaging with WildFly and AMQ 7 on OpenShift
 :summary: Discover how to configure WildFly with AMQ 7 (ActiveMQ Artemis) on OpenShift, using a clustered, high-availability topology for reliable messaging.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 20
 
 In this guide, you will learn how to configure a WildFly server connected to a remote AMQ 7 cluster on OpenShift using operators.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
 * Access to an OpenShift cluster (consider using the 'Self-managed' variant for a local development environment, available for free at https://developers.redhat.com/products/openshift/download[Red Hat OpenShift, window=_blank])
-* https://docs.openshift.com/container-platform/\{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI, window=_blank] tool
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI, window=_blank] tool
 * link:https://podman.io/[Podman, window="_blank"] (link:https://www.docker.com/[Docker, window="_blank"] is also compatible with minor adjustments)
 
 // login to OpenShift cluster
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{|
 == Install and deploy AMQ 7 using an operator
 
 To install the AMQ 7 Operator, follow the instructions in the Red Hat documentation: https://access.redhat.com/documentation/en-us/red_hat_amq_broker/7.12/html-single/deploying_amq_broker_on_openshift/index#proc-br-installing-operator-to-project-from-operatorhub_broker-ocp[Installing the Operator using OperatorHub, window=_blank]
@@ -299,4 +298,3 @@ These resources provide valuable insights and tools to optimize your WildFly and
 * https://docs.wildfly.org/wildfly-maven-plugin/releases/5.0/[WildFly Maven Plugin Documentation, window=_blank]
 * https://activemq.apache.org/components/artemis/documentation/latest/clusters.html#overview[Apache ActiveMQ Artemis Documentation - Clusters, window=_blank]
 * https://docs.redhat.com/en/documentation/red_hat_jboss_enterprise_application_platform/7.4/html-single/configuring_messaging/index#clusters_overview[EAP 7.4 Messaging Clusters Overview, window=_blank]
-|}

--- a/content/guides/messaging-high-availability.adoc
+++ b/content/guides/messaging-high-availability.adoc
@@ -3,13 +3,12 @@ layout: guide
 ---
 = Configure WildFly with a Messaging (ActiveMQ Artemis) Cluster and High Availability
 :summary: Learn how to configure WildFly with a messaging (ActiveMQ Artemis) cluster and high availability
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 20
 
-{|
 In this guide you will learn how to configure two WildFly servers with messaging (integrated ActiveMQ Artemis broker)
 in a high availability topology with https://activemq.apache.org/components/artemis/documentation/latest/ha.html#shared-store[shared journal, window=_blank].
 
@@ -229,4 +228,3 @@ More information can be found in the https://activemq.apache.org/components/arte
 
 * https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.4/html-single/configuring_messaging/index#messaging-ha[Configuring Messaging guide for EAP 7.4, window=_blank]
 * https://activemq.apache.org/components/artemis/documentation/[ActiveMQ Artemis documentation, window=_blank]
-|}

--- a/content/guides/prototyping-with-jbang.adoc
+++ b/content/guides/prototyping-with-jbang.adoc
@@ -3,13 +3,12 @@ layout: guide
 ---
 = Prototype WildFly applications with JBang
 :summary: Learn how to use JBang to prototype simple WildFly applications from a single Java source file.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 15
 
-{|
 In this guide, you will learn how to use https://jbang.dev[JBang] to prototype enterprise Java applications running with WildFly.
 
 [[prerequisites]]
@@ -325,4 +324,3 @@ For a deeper dive into prototyping WildFly applications with JBang (including wr
 
 * https://www.jbang.dev[JBang Home Page]
 * https://docs.wildfly.org/wildfly-glow/#jbang[WildFly Glow documentation to run WildFly with JBang]
-|}

--- a/content/guides/security-credential-store-client-config.adoc
+++ b/content/guides/security-credential-store-client-config.adoc
@@ -3,16 +3,15 @@ layout: guide
 ---
 = Using Credential Stores for WildFly Client
 :summary: How to set up a credential store using the elytron-tool and use it for the client configuration on an application deployed to WildFly.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 10
 
 WildFly allows the use of credential stores to keep aliases for sensitive information, such as, passwords for external services. Credential stores can be used to store different credentials under aliases and use credential-reference to specify them in server configuration. As a result, the credential is no longer visible in clear text. However, there are additional uses for credential store as well. This guides explains how to create credential stores using the elytron-tool and use it for an application deployed to WildFly.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Elytron-tool (provided with WildFly)
 
-{|
 == Access the Example Application
 For this guide we will be using the `ejb-security` example application. Let us first clone the project and navigate to it:
 
@@ -169,5 +168,3 @@ This guide demonstrates how a `credential-store` can be used to specify identity
 * https://docs.wildfly.org/33/WildFly_Elytron_Security.html#CredentialStore[Credential-Stores]
 * https://docs.wildfly.org/33/WildFly_Elytron_Security.html#credential-store-creation[Creating credential-stores using the Elytron-tool]
 * To learn more about the functions of elytron-tool, you can use the `./bin/elytron-tool.sh -h` command from `WILDFLY_HOME`.
-
-|}

--- a/content/guides/security-credential-store-enc-exp.adoc
+++ b/content/guides/security-credential-store-enc-exp.adoc
@@ -3,15 +3,14 @@ layout: guide
 ---
 = Using Credential Stores With Encrypted Expressions With WildFly
 :summary: How to set up encrypted expressions and use it to replace sensitive information specified as clear-text on applications deployed to WildFly.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 10
 
 WildFly allows the use of credential stores to keep alias for sensitive information, such as, passwords for external services. Credential stores can be used to store different credentials under aliases and use credential-reference to specify them in server configuration. As a result, the sensitive information is no longer visible in clear text.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
-{|
 == Prerequisite
 To follow along with this guide you will need:
 
@@ -165,4 +164,3 @@ This guide demonstrates three use cases where we can use encrypted expressions t
 * https://docs.wildfly.org/33/WildFly_Elytron_Security.html#EncryptedExpressions[Encrypted Expressions]
 * https://docs.wildfly.org/33/WildFly_Elytron_Security.html#CredentialStore[Credential Stores]
 * https://docs.wildfly.org/33/wildscribe/system-property/index.html[System Properties]
-|}

--- a/content/guides/security-credential-store-for-passwords.adoc
+++ b/content/guides/security-credential-store-for-passwords.adoc
@@ -3,15 +3,14 @@ layout: guide
 ---
 = Using Credential Stores to Replace Clear Text Passwords With WildFly
 :summary: How to use credential stores to specify passwords for resources.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 10
 
 WildFly allows the use of credential stores to keep aliases for sensitive information, such as, passwords for external services. Credential stores can be used to store different credentials under aliases and use credential-reference to specify them in server configuration. As a result, the credential is no longer visible in clear text.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
-{|
 == About Credential Reference
 There are multiple uses for credential stores, but this blog post will dive deeper into using credential-stores to avoid specifying passwords in clear text. Passwords are used for various resources when configuring the WildFly server, such as a `key-store` or a `key-manager`. While it is quick and easy to specify the passwords in clear text, it is not very secure.
 
@@ -188,4 +187,3 @@ This blog post introduces us to credential stores and introduces us to one of th
 * To learn more about credential stores, please refer to the https://docs.wildfly.org/33/WildFly_Elytron_Security.html#CredentialStore[documentation]
 * To learn more about automatic credential-store updates, visit https://wildfly-security.github.io/wildfly-elytron/blog/automatic-credential-store-updates/[this blog post]
 * You can also use the `read-resource-description` function in command line to learn more about the credential-reference resource.
-|}

--- a/content/guides/security-oidc-auth0-openshift.adoc
+++ b/content/guides/security-oidc-auth0-openshift.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Securing WildFly Apps with Auth0 on OpenShift
 :summary: Learn how to secure applications deployed to WildFly on OpenShift with the Auth0 OpenID provider.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
 You can secure your WildFly applications deployed on OpenShift with OpenID Connect (OIDC). By using OIDC to secure
@@ -14,8 +14,7 @@ deployed to WildFly on OpenShift with OIDC using https://auth0.com/[Auth0] as th
 If you prefer to watch a video, check out this 5-minute https://www.youtube.com/watch?v=uoQoCPGyAik[video] which also covers the steps
 from this guide.
 
-{#include partials/guides/prerequisites.adoc /}
-{|
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
 * https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 * https://helm.sh/docs/intro/install/[Helm Chart]
@@ -33,10 +32,8 @@ To obtain this example, clone the `elytron-examples` repository to your local ma
 ----
 git clone git@github.com:wildfly-security-incubator/elytron-examples.git
 ----
-|}
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{|
 == Configure Auth0
 
 We will be using Auth0 as our OpenID provider.
@@ -96,11 +93,9 @@ as described below.
 <3> Replace `<AUTH0_CLIENT_SECRET>` with the `Client Secret` value from your OIDC App's `Basic Information` section in the *Auth0 Dashboard*.
 
 == Deploy the Example Application to WildFly on OpenShift
-|}
 
-{#include partials/guides/proc-install-or-update-helm.adoc /}
+include::../../templates/partials/guides/proc-install-or-update-helm.adoc[]
 
-{|
 We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
 
 [source,bash]
@@ -110,10 +105,8 @@ helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-auth0/charts/he
 
 Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
 needed to build and deploy our application.
-|}
-{#include partials/guides/proc-follow-build-and-deployment-openshift.adoc /}
+include::../../templates/partials/guides/proc-follow-build-and-deployment-openshift.adoc[]
 
-{|
 === Behind the Scenes
 
 While our application is building, let's take a closer look at our application.
@@ -259,4 +252,3 @@ documentation.
 * https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 * https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Chart]
 * <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>
-|}

--- a/content/guides/security-oidc-identity-propagation.adoc
+++ b/content/guides/security-oidc-identity-propagation.adoc
@@ -3,21 +3,18 @@ layout: guide
 ---
 = Identity Propagation with OpenID Connect
 :summary: Learn how to propagate identities within a deployment and across deployments when securing apps with OpenID Connect.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
-{|
 When securing an application with OpenID Connect (OIDC), WildFly https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#virtual-security-2[automatically]
 creates and makes use of a virtual security domain across the deployment. If the application invokes an EJB, additional configuration
 might be required in order to propagate the security identity from the virtual security domain. The configuration that's needed
 depends on how the EJB that's being invoked is secured. This guide covers the different use cases for propagating an identity
 from a virtual security domain.
-|}
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * https://www.keycloak.org/guides#getting-started[Keycloak]
 
-{|
 == Overview of Identity Propagation with OIDC
 
 Additional configuration might be needed in order to propagate a security identity from a virtual security domain depending
@@ -83,11 +80,9 @@ This guide will be making use of Keycloak as our OpenID provider.
 
 To start a Keycloak server in your environment, follow the appropriate guide for your environment
 from Keycloak’s https://www.keycloak.org/guides#getting-started[Getting Started] page.
-|}
 :add-role:
-{#include partials/guides/proc-configure-keycloak.adoc /}
+include::../../templates/partials/guides/proc-configure-keycloak.adoc[]
 
-{|
 == Secure an EJB Invoked by an OIDC App using a Different Security Domain
 
 For this use case, we'll be using the https://github.com/wildfly-security-incubator/elytron-examples/tree/main/oidc-with-identity-propagation[oidc-with-identity-propagation] example.
@@ -404,4 +399,3 @@ documentation.
 * https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#Elytron_OIDC_Client[Elytron OpenID Connect Client Subsystem Configuration]
 * https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
 * <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>
-|}

--- a/content/guides/security-oidc-management-console.adoc
+++ b/content/guides/security-oidc-management-console.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Securing the WildFly Management Console with OpenID Connect
 :summary: Learn how to secure the WildFly management console with the Keycloak OpenID provider.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
 You can secure the WildFly Management Console with OpenID Connect (OIDC) using the Keycloak
@@ -13,10 +13,9 @@ access the console, they will be redirected to the Keycloak OpenID provider's lo
 authentication, the user will then be redirected back to the WildFly Management Console. This guide
 explains how to configure this.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * https://www.keycloak.org/guides#getting-started[Keycloak]
 
-{|
 == Start Keycloak
 
 This guide will be making use of Keycloak as our OpenID provider.
@@ -130,4 +129,3 @@ documentation.
 * https://www.keycloak.org/guides#getting-started[Getting Started with Keycloak]
 * https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
 * <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>
-|}

--- a/content/guides/security-oidc-okta-openshift.adoc
+++ b/content/guides/security-oidc-okta-openshift.adoc
@@ -3,13 +3,13 @@ layout: guide
 ---
 = Securing WildFly Applications Using Okta on OpenShift
 :summary: A step by step guide on how to secure a WildFly application using Okta's OpenID Provider and deploy it to OpenShift.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
 WildFly applications can be secured using OpenID Connect (OIDC) and deployed to OpenShift. By using OIDC to secure applications, you delegate authentication to OIDC providers. The `elytron-oidc-client` subsystem can be used to secure an application deployed to WildFly using any OpenID Provider. This guide demonstrates how to secure an example application deployed to WildFly on OpenShift using https://www.okta.com/[Okta] as the OpenID Provider.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Roughly 15 minutes
 * Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
 * https://docs.openshift.com/container-platform/4.14/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
@@ -28,9 +28,8 @@ git clone git@github.com:wildfly-security-incubator/elytron-examples.git
 cd simple-webapp-okta
 ----
 
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{|
 == Configure Okta
 
 For this guide, we will be using Okta as our OpenID provider. In order to secure the application, we will need to access the Okta web console and register our application as a client. The following set of steps outlines how to register an OpenID web-application with Okta:
@@ -124,9 +123,8 @@ You can view the deployment configuration used in this example by navigating to 
 Now that we have added the required changes, we can deploy our application, the helm chart will specify the location for this example application and pull information needed for our deployment specified in the `oidc.json` file.
 
 == Deploy the Example Application to WildFly on OpenShift
-|}
 
-{#include partials/guides/proc-install-or-update-helm.adoc /}
+include::../../templates/partials/guides/proc-install-or-update-helm.adoc[]
 
 We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
 
@@ -136,9 +134,8 @@ helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml/charts/hel
 ----
 Notice that this command specifies the file we updated, `helm.yaml`, that contains the values needed to build and deploy our application.
 
-{#include partials/guides/proc-follow-build-and-deployment-openshift.adoc /}
+include::../../templates/partials/guides/proc-follow-build-and-deployment-openshift.adoc[]
 
-{|
 === Behind the Scenes
 
 While our application is building, let’s take a closer look at our application.
@@ -263,4 +260,3 @@ This guide demonstrates how to use an OpenID provider other than Keycloak to sec
 * https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 * https://docs.wildfly.org/31/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Charts]
 * <<security-oidc-openshift.adoc#security-oidc-openshift,Securing WildFly Apps with OIDC on OpenShift>>
-|}

--- a/content/guides/security-oidc-openshift.adoc
+++ b/content/guides/security-oidc-openshift.adoc
@@ -5,16 +5,15 @@ aliases: [/guides/security-oidc-openshift.html]
 [[security-oidc-openshift]]
 = Securing WildFly Apps with OIDC on OpenShift
 :summary: Learn how to secure applications deployed to WildFly on OpenShift with OpenID Connect.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
 You can secure your WildFly applications deployed on OpenShift with OpenID Connect (OIDC). By using OIDC
 to secure applications, you delegate authentication to OIDC providers. This guide shows how to secure an
 example application deployed to WildFly on OpenShift with OIDC using Keycloak as the OpenID provider.
 
-{#include partials/guides/prerequisites.adoc /}
-{|
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
 * https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 * https://helm.sh/docs/intro/install/[Helm Chart]
@@ -31,14 +30,12 @@ To obtain this example, clone the `elytron-examples` repository to your local ma
 ----
 git clone git@github.com:wildfly-security-incubator/elytron-examples.git
 ----
-|}
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{#include partials/guides/proc-start-keycloak-openshift.adoc /}
+include::../../templates/partials/guides/proc-start-keycloak-openshift.adoc[]
 
-{#include partials/guides/proc-configure-keycloak.adoc /}
+include::../../templates/partials/guides/proc-configure-keycloak.adoc[]
 
-{|
 == Add Helm Configuration
 
 . Obtain the URL for Keycloak.
@@ -74,8 +71,7 @@ deploy:
 <1> Replace `<KEYCLOAK_URL>` with the Keycloak URL obtained in the previous command.
 
 == Deploy the Example Application to WildFly on OpenShift
-|}
-{#include partials/guides/proc-install-or-update-helm.adoc /}
+include::../../templates/partials/guides/proc-install-or-update-helm.adoc[]
 
 We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
 
@@ -87,7 +83,7 @@ helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-oidc/charts/hel
 Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
 needed to build and deploy our application.
 
-{#include partials/guides/proc-follow-build-and-deployment-openshift.adoc /}
+include::../../templates/partials/guides/proc-follow-build-and-deployment-openshift.adoc[]
 
 === Behind the Scenes
 
@@ -98,7 +94,6 @@ While our application is building, let's take a closer look at our application.
 Notice that it contains an `openshift` profile. A profile in Maven lets you create a set of configuration values to customize your application build for different environments.
 The `openshift` profile in this example defines a configuration that will be used by the WildFly Helm Chart when provisioning the WildFly server on OpenShift.
 +
-{|
 [source,xml]
 ----
 <profiles>
@@ -232,4 +227,3 @@ documentation.
 * https://docs.wildfly.org/{wildfly-version}/Getting_Started_on_OpenShift.html#helm-charts[WildFly Helm Chart]
 * https://www.keycloak.org/getting-started/getting-started-openshift[Getting started with Keycloak on OpenShift]
 * https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
-|}

--- a/content/guides/security-oidc-request-openshift.adoc
+++ b/content/guides/security-oidc-request-openshift.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Sending Request Objects as A JWT Using Request Parameters for OpenID Connect
 :summary: How to send the request object as a Json Web Token when securing a WildFly application using OpenID Connect on Openshift.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 20
 
 WildFly 33 includes the ability to send the request object as a Json Web Token (JWT) when securing an application using OIDC.
@@ -14,7 +14,7 @@ provider. The OAuth 2.0 request syntax sends the Request Object in the request b
 However, OpenID Connect allows the Request Object to be sent as a JWT using https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests[request parameters], which can be signed and optionally
 encrypted. This adds an added layer of protection, as the parameters are no longer human-readable.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the Red Hat Developer Sandbox for free)
 
 * https://docs.openshift.com/container-platform/4.15/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
@@ -79,11 +79,10 @@ Take a note of the absolute path of the keystore file along with the key alias a
 
 If you would like to use JKS keystore files instead, see https://docs.redhat.com/en/documentation/red_hat_jboss_data_virtualization/6.4/html/security_guide/create_a_privatepublic_key_pair_with_keytool[here] for more information.
 
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{#include partials/guides/proc-start-keycloak-openshift.adoc /}
+include::../../templates/partials/guides/proc-start-keycloak-openshift.adoc[]
 
-{|
 === OpenShift Web Console
 To make sure your Keycloak server has been provisioned using the OpenShift web console, navigate to the *Topology* view in the *Developer* perspective. You can click on your *keycloak* app to check its status. Once it is running, you can click on *Open URL* and you will be taken to Keycloak’s *Administration Console* login page.
 
@@ -412,4 +411,3 @@ documentation of your OpenID provider.
 * https://docs.wildfly.org/33/Admin_Guide.html#Feature_stability_levels[Feature stability levels]
 * https://docs.wildfly.org/33/Galleon_Guide.html#WildFly_Galleon_feature-packs[WildFly Galleon feature-packs]
 * https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html[Keytool documentation].
-|}

--- a/content/guides/security-oidc-scope-openshift.adoc
+++ b/content/guides/security-oidc-scope-openshift.adoc
@@ -3,15 +3,15 @@ layout: guide
 ---
 = Securing WildFly Apps on OpenShift with OpenID Connect Using Additional Scope Values
 :summary: Learn how to secure applications deployed to WildFly on OpenShift with OpenID Connect using additional scope values.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 15
 
 WildFly 32 includes the ability to add additional scope values when securing applications using OpenID Connect (OIDC). This new feature is available at the https://docs.wildfly.org/32/Admin_Guide.html#Feature_stability_levels[Preview stability level]. https://openid.net/developers/how-connect-works/[ OpenID Connect] is an identity layer on top of the OAuth 2.0 protocol that makes it possible for a client to verify a user’s identity based on authentication that’s performed by an OpenID provider. The https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[OpenID Connect specification] indicates that there are other scope values which may be included in the authentication request to ask permission to access additional and specific resources. This guide shows how to configure additional scope values when securing a WildFly app with OpenID Connect on OpenShift.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the Red Hat Developer Sandbox for free)
 
 * https://docs.openshift.com/container-platform/4.15/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
@@ -31,11 +31,10 @@ To obtain this example, clone the elytron-examples repository to your local mach
 git clone git@github.com:wildfly-security-incubator/elytron-examples.git
 ----
 
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{#include partials/guides/proc-start-keycloak-openshift.adoc /}
+include::../../templates/partials/guides/proc-start-keycloak-openshift.adoc[]
 
-{|
 === OpenShift Web Console
 To make sure your Keycloak server has been provisioned using the OpenShift web console, navigate to the *Topology* view in the *Developer* perspective. You can click on your *keycloak* app to check its status. Once it is running, you can click on *Open URL* and then access Keycloak’s *Administration Console*.
 
@@ -103,8 +102,7 @@ Additionally, we have used the `stability` galleon option to specify the stabili
 ----
 
 == Deploy the Example Application to WildFly on OpenShift
-|}
-{#include partials/guides/proc-install-or-update-helm.adoc /}
+include::../../templates/partials/guides/proc-install-or-update-helm.adoc[]
 
 We can deploy our example application to WildFly on OpenShift using the WildFly Helm Chart:
 
@@ -115,9 +113,8 @@ helm install oidc-app -f /PATH/TO/ELYTRON/EXAMPLES/elytron-oidc-client-scope/cha
 
 Notice that this command specifies the file we updated, `helm.yaml`, that contains the values needed to build and deploy our application.
 
-{#include partials/guides/proc-follow-build-and-deployment-openshift.adoc /}
+include::../../templates/partials/guides/proc-follow-build-and-deployment-openshift.adoc[]
 
-{|
 == Behind the Scenes
 While our application is building, let’s take a closer look at our application.
 
@@ -277,4 +274,3 @@ This example has demonstrated how to secure a WildFly application deployed to Op
 * https://www.keycloak.org/docs/latest/securing_apps/#_oidc[Using OpenID Connect to secure applications and services]
 * https://docs.wildfly.org/32/Admin_Guide.html#Feature_stability_levels[Feature stability levels]
 * https://docs.wildfly.org/32/Galleon_Guide.html#WildFly_Galleon_feature-packs[WildFly Galleon feature-packs]
-|}

--- a/content/guides/security-saml-openshift.adoc
+++ b/content/guides/security-saml-openshift.adoc
@@ -3,16 +3,15 @@ layout: guide
 ---
 = Securing WildFly Apps with SAML on OpenShift
 :summary: Learn how to secure applications deployed to WildFly on OpenShift with SAML.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 15
 
 You can secure your WildFly applications deployed on OpenShift with Security Assertion Markup Language (SAML).
 By using SAML to secure applications, you delegate authentication to SAML identity providers (IdPs). This guide shows
 how to secure an example application deployed to WildFly on OpenShift with SAML using Keycloak as the SAML IdP.
 
-{#include partials/guides/prerequisites.adoc /}
-{|
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the https://developers.redhat.com/developer-sandbox[Red Hat Developer Sandbox] for free)
 * https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 * https://helm.sh/docs/intro/install/[Helm Chart]
@@ -29,14 +28,12 @@ To obtain this example, clone the `elytron-examples` repository to your local ma
 ----
 git clone git@github.com:wildfly-security-incubator/elytron-examples.git
 ----
-|}
 
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
 :saml-auth-method:
-{#include partials/guides/proc-start-keycloak-openshift.adoc /}
+include::../../templates/partials/guides/proc-start-keycloak-openshift.adoc[]
 
-{|
 == Configure Keycloak
 
 . Log into the `Keycloak Admin Console`.
@@ -176,11 +173,9 @@ helm install saml-app -f /PATH/TO/ELYTRON/EXAMPLES/simple-webapp-saml/charts/hel
 
 Notice that this command specifies the file we updated, `helm.yaml`, that contains the values
 needed to build and deploy our application.
-|}
 
-{#include partials/guides/proc-follow-build-and-deployment-openshift.adoc /}
+include::../../templates/partials/guides/proc-follow-build-and-deployment-openshift.adoc[]
 
-{|
 === Behind the Scenes
 
 While our application is building, let's take a closer look at our application's https://github.com/wildfly-security-incubator/elytron-examples/blob/main/simple-webapp-saml/pom.xml[pom.xml] file.
@@ -282,4 +277,3 @@ information, feel free to check out the resources linked below.
 * https://www.keycloak.org/getting-started/getting-started-openshift[Getting started with Keycloak on OpenShift]
 * https://www.keycloak.org/docs/latest/server_admin/index.html[Keycloak Server Administration Guide]
 * https://www.keycloak.org/docs/latest/securing_apps/#using-saml-to-secure-applications-and-services[Using SAML to secure applications and services]
-|}

--- a/content/guides/template.adoc
+++ b/content/guides/template.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = TITLE OF THE GUIDE
 :summary: ONELINE EXPLANATION OF THE GUIDE
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 10
@@ -14,10 +14,9 @@ Something like:
 
 In this guide, you will learn how to setup and use Eclipse MicroProfile Config in your application.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Any additional prerequisites specific to this guide (eg you have completed a previous guide)
 
-{|
 == A section
 
 Lorem ipsum
@@ -38,4 +37,3 @@ MicroProfile Config provides multiple options to read the configuration from var
 
 * https://microprofile.io/specifications/microprofile-config/[Eclipse MicroProfile Config]
 * https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#MicroProfile_Config_SmallRye[MicroProfile Config Subsystem Configuration]
-|}

--- a/content/guides/testing-arquillian-junit5.adoc
+++ b/content/guides/testing-arquillian-junit5.adoc
@@ -3,8 +3,8 @@ layout: guide
 ---
 = Testing WildFly Applications with Arquillian and JUnit 5
 :summary: Testing applications with WildFly, Arquillian and JUnit 5
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 // you can override any attributes eg to lengthen the
 // time to complete the guide
 :prerequisites-time: 15
@@ -12,9 +12,8 @@ layout: guide
 In this guide you will learn how to setup your project for testing with Arquillian and JUnit 5. We will use the
 https://github.com/wildfly-extras/guides/tree/main/arquillian-junit5[arquillian-junt5] example project in this guide.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
-{|
 == Add JUnit and Arquillian Dependencies
 
 In order to use JUnit and Arquillian for your tests, you need to update the Maven `pom.xml`. The best practice is to
@@ -294,4 +293,3 @@ on WildFly.
 * https://arquillian.org[Arquillian]
 * https://docs.wildfly.org/wildfly-maven-plugin[WildFly Maven Plugin]
 * https://github.com/wildfly-extras/guides/tree/main/arquillian-junit5[Example Project]
-|}

--- a/content/guides/use-microprofile-amqp-connector-with-ssl-openshift.adoc
+++ b/content/guides/use-microprofile-amqp-connector-with-ssl-openshift.adoc
@@ -3,23 +3,20 @@ layout: guide
 ---
 :summary: Learn how to securely connect to AMQ 7 deployed on OpenShift using MicroProfile Reactive Messaging application using AMQP connector.
 :prerequisites-time: 20
-{#include partials/guides/attributes.adoc /}
+include::../../templates/partials/guides/attributes.adoc[]
 
 = Use MicroProfile Reactive Messaging with AMQP Connector with SSL Connection to AMQ 7 on OpenShift
 
 In this guide, we will learn how to set up MicroProfile Reactive Messaging application with AMQP Connector
 to connect to AMQ 7 deployed on OpenShift. Communication will be secured using SSL/TLS.
 
-{#include partials/guides/prerequisites.adoc /}
-{|
+include::../../templates/partials/guides/prerequisites.adoc[]
 * Access to an OpenShift cluster (try the "Self-managed" variant of local development machine https://developers.redhat.com/products/openshift/download[Red Hat OpenShift
 ] for free)
-* https://docs.openshift.com/container-platform/\{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
-|}
+* https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]
 // login to OpenShift cluster
-{#include partials/guides/proc-log-into-openshift-cluster.adoc /}
+include::../../templates/partials/guides/proc-log-into-openshift-cluster.adoc[]
 
-{|
 == Deploy AMQ 7 using operator
 === Install AMQ 7 operator
 Follow instruction in https://access.redhat.com/documentation/en-us/red_hat_amq_broker/7.11/html-single/deploying_amq_broker_on_openshift/index#proc-br-installing-operator-to-project-from-operatorhub_broker-ocp[Installing the Operator using OperatorHub]
@@ -120,7 +117,7 @@ cd guides/microprofile-reactive-messaging-amqp-connector-example/
 The important part of the application is `microprofile-config.properties` file configuring secured AMQP connector to remote AMQ 7 broker:
 [source, bash, options="nowrap"]
 ----
-amqp-host=$\{AMQ_HOST}
+amqp-host=${AMQ_HOST}
 amqp-port=443
 amqp-username=admin
 amqp-password=admin
@@ -207,4 +204,3 @@ WildFly MicroProfile Reactive Messaging provides multiple options to connect to 
 * https://artemiscloud.io/docs/tutorials/ssl_broker_setup/[Setting up SSL connections with ArtemisCloud Operator]
 * https://docs.wildfly.org/31/Admin_Guide.html#MicroProfile_Reactive_Messaging_SmallRye[MicroProfile Reactive Messaging Subsystem Configuration]
 * https://docs.wildfly.org/wildfly-glow/[WildFly Glow Documentation]
-|}

--- a/content/guides/use-microprofile-config.adoc
+++ b/content/guides/use-microprofile-config.adoc
@@ -3,15 +3,14 @@ layout: guide
 ---
 = Using MicroProfile Config
 :summary: Learn how to use MicroProfile Config With WildFly.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 :prerequisites-time: 10
 
 In this guide, you will learn how to setup and use Eclipse MicroProfile Config in your application.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
-{|
 [[requirements]]
 == Configure Your App to make use of MicroProfile Config
 
@@ -133,4 +132,3 @@ MicroProfile Config provides multiple options to read the configuration from var
 
 * https://microprofile.io/specifications/microprofile-config/[Eclipse MicroProfile Config]
 * https://docs.wildfly.org/{wildfly-version}/Admin_Guide.html#MicroProfile_Config_SmallRye[MicroProfile Config Subsystem Configuration]
-|}

--- a/content/guides/use-microprofile-lra.adoc
+++ b/content/guides/use-microprofile-lra.adoc
@@ -3,14 +3,13 @@ layout: guide
 ---
 = Using MicroProfile LRA
 :summary: Learn how to use MicroProfile LRA With WildFly.
-:includedir: _includes
-{#include partials/guides/attributes.adoc /}
+:includedir: /templates
+include::../../templates/partials/guides/attributes.adoc[]
 
 In this guide, you will learn how to setup and use Eclipse MicroProfile LRA in your application.
 
-{#include partials/guides/prerequisites.adoc /}
+include::../../templates/partials/guides/prerequisites.adoc[]
 
-{|
 == Introduction
 
 https://download.eclipse.org/microprofile/microprofile-lra-2.0/microprofile-lra-spec-2.0.html[MicroProfile Long Running
@@ -168,4 +167,3 @@ $ curl localhost:8080/lra-coordinator/lra-coordinator
 In this guide, we showed you how to configure and use the MicroProfile LRA specification in your WildFly applications.
 LRA provides a very broad feature set which we can't cover here. If you are interested in learning more, you can find
 the full specification at https://download.eclipse.org/microprofile/microprofile-lra-2.0/microprofile-lra-spec-2.0.html.
-|}

--- a/content/posts/2014-02-06-GlassFish-to-WildFly-migration.adoc
+++ b/content/posts/2014-02-06-GlassFish-to-WildFly-migration.adoc
@@ -127,9 +127,9 @@ The command returns `{"outcome" => "success"}` in case of success. This command 
 [source,xml]
 ----
     <datasources>
-        \{...}
+        {...}
         <drivers>
-            \{...}
+            {...}
             <driver name="mysql" module="com.mysql">
                 <driver-class>com.mysql.jdbc.Driver</driver-class>
             </driver>
@@ -187,7 +187,7 @@ The resulting part made by the console/command in the configuration file are:
 [source,xml]
 ----
     <datasources>
-        \{...}
+        {...}
         <datasource jndi-name="java:/jdbc/AppDS" pool-name="AppDS" enabled="true" use-java-context="true">
             <connection-url>jdbc:mysql://localhost:3306/app</connection-url>
             <driver>mysql</driver>
@@ -206,7 +206,7 @@ The resulting part made by the console/command in the configuration file are:
                 <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter”/>
             </validation>
         </datasource>
-        \{...}
+        {...}
     </datasources>
 ----
 
@@ -277,10 +277,12 @@ NOTE: At the time of this writing, WildFly Beta's admin console was not mature e
 
 Considering the data model in the figure above, go to the command line and type the following command to create the security domain:
 
+[source]
+-----
     ./subsystem=security/security-domain=app:add(cache-type="default")
       cd ./subsystem=security/security-domain=app
          ./authentication=classic:add(
-           login-modules=[ \{
+           login-modules=[ {
              code="Database",
              flag="required",
              module-options={
@@ -292,7 +294,7 @@ Considering the data model in the figure above, go to the command line and type 
                hashEncoding="BASE64",
                unauthenticatedIdentity="guest"
              }
-           }, \{
+           }, {
              code="RoleMapping",
              flag="required",
              module-options={
@@ -301,6 +303,7 @@ Considering the data model in the figure above, go to the command line and type 
              }
            }
          ])
+-----
 
 The resulting part made by the command in the configuration file are:
 [source,xml]

--- a/content/posts/2015-05-05-WildFly-Swarm-Released.adoc
+++ b/content/posts/2015-05-05-WildFly-Swarm-Released.adoc
@@ -89,9 +89,9 @@ perform whatever deployments you need, that's possible also!
 
 [source,java]
 ------------------------------
-public class Main \{
+public class Main {
 
-    public static void main(String[] args) throws Exception \{
+    public static void main(String[] args) throws Exception {
         Container container = new Container();
 
         container.subsystem(new MessagingFraction()
@@ -161,4 +161,3 @@ Stay in Touch
 You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].
-

--- a/content/posts/2015-06-05-WildFly-Swarm-Alpha2.adoc
+++ b/content/posts/2015-06-05-WildFly-Swarm-Alpha2.adoc
@@ -43,9 +43,9 @@ packaging, not `war`, and you will need your own Main:
 
 [source,java]
 ------------------------------
-public class Main \{
+public class Main {
 
-    public static void main(String[] args) throws Exception \{
+    public static void main(String[] args) throws Exception {
       Container container = new Container();
       container.start();
 
@@ -119,4 +119,3 @@ and continue doing your builds.  Everything is available through Maven Central.
 You can keep up with the project through the link:https://www.hipchat.com/gSW9XYz69[WildFly HipChat]
 room, link:http://twitter.com/wildflyswarm[@wildflyswarm on Twitter], or through
 link:https://github.com/wildfly-swarm/wildfly-swarm/issues[GitHub Issues].
-

--- a/content/posts/2015-07-25-Wildfly-And-ELK.adoc
+++ b/content/posts/2015-07-25-Wildfly-And-ELK.adoc
@@ -17,21 +17,21 @@ Next we will need to create a configuraton file. In the logstash directory creat
 
 [source,yaml]
 ----
-input \{
-  tcp \{
+input {
+  tcp {
     port => 8000
   }
 }
 
-filter \{
-  json \{
+filter {
+  json {
     source => "message"
   }
 }
 
-output \{
+output {
 
-  elasticsearch \{
+  elasticsearch {
     # Use the embedded elsasticsearch for convienence
     embedded => true
     protocol => "http"

--- a/content/posts/2015-08-10-Javascript-Support-In-Wildfly.adoc
+++ b/content/posts/2015-08-10-Javascript-Support-In-Wildfly.adoc
@@ -48,8 +48,8 @@ A simple HTTP endpoint
 ----
 $undertow
     .onGet("/hello",
-        \{headers: \{"content-type": "text/plain"}},
-        [function ($exchange) \{
+        {headers: {"content-type": "text/plain"}},
+        [function ($exchange) {
             return "Hello World";
         }])
 ----
@@ -72,9 +72,9 @@ Now lets try a simple JSON REST endpoint:
 ----
 $undertow
     .onGet("/rest/endpoint",
-        \{headers: \{"content-type": "application/json"}},
-        [function ($exchange) \{
-            return \{message: 'Hello World'};
+        {headers: {"content-type": "application/json"}},
+        [function ($exchange) {
+            return {message: 'Hello World'};
         }])
 ----
 
@@ -88,8 +88,8 @@ datasource:
 ----
 $undertow
     .onGet("/rest/members",
-        \{headers: \{"content-type": "application/json"}},
-        ['jndi:java:jboss/datasources/ExampleDS', function ($exchange, db) \{
+        {headers: {"content-type": "application/json"}},
+        ['jndi:java:jboss/datasources/ExampleDS', function ($exchange, db) {
             return db.select("select * from members");
         }])
 ----
@@ -132,18 +132,18 @@ Lets address those issues:
 $undertow
     .alias('db', 'jndi:java:jboss/datasources/ExampleDS')
     .onGet("/rest/members",
-        \{headers: \{"content-type": "application/json"}},
-        ['db', function ($exchange, db) \{
+        {headers: {"content-type": "application/json"}},
+        ['db', function ($exchange, db) {
             return db.select("select * from member");
         }]);
 
 
 var db = $undertow.resolve("db");
-try \{
+try {
     db.query("create table member (id serial primary key not null, name varchar(100), email varchar(100) unique, phone_number varchar(100))");
     db.query("insert into member (id, name, email, phone_number) values (0, 'John Smith', 'john.smith@mailinator.jsp.com', '2125551212')");
     db.query("insert into member (id, name, email, phone_number) values (1, 'Stuart Douglas', 'stuart@notmyrealaddress.com', '0487694837')");
-} catch(e) \{
+} catch(e) {
     print("DB create failed")
 }
 ----
@@ -165,9 +165,9 @@ value of your function as the data. An example is shown below:
 ----
 $undertow
     .onGet("/hello",
-        \{template: 'hello.txt', headers: \{"content-type": "text/plain"}},
-        [function ($exchange) \{
-            return \{name: 'Stuart'};
+        {template: 'hello.txt', headers: {"content-type": "text/plain"}},
+        [function ($exchange) {
+            return {name: 'Stuart'};
         }]);
 ----
 
@@ -175,7 +175,7 @@ And in `hello.txt`:
 
 [source]
 ----
-Hello \{{name}}
+Hello {{name}}
 ----
 
 Handling POST requests
@@ -191,18 +191,18 @@ An example of all three approaches is shown below:
 ----
 $undertow
     .onPost("/string",
-        \{headers: \{"content-type": "text/plain"}},
-        ['$entity', function ($exchange, entity) \{
+        {headers: {"content-type": "text/plain"}},
+        ['$entity', function ($exchange, entity) {
             return "You posted: " + entity;
         }])
     .onPost("/json",
-        \{headers: \{"content-type": "text/plain"}},
-        ['$entity:json', function ($exchange, entity) \{
+        {headers: {"content-type": "text/plain"}},
+        ['$entity:json', function ($exchange, entity) {
                 return "You posted: " + entity['name'];
         }])
     .onPost("/form",
-        \{headers: \{"content-type": "text/plain"}},
-        ['$entity:form', function ($exchange, entity) \{
+        {headers: {"content-type": "text/plain"}},
+        ['$entity:form', function ($exchange, entity) {
             return "You posted: " + entity.get('name');
         }])
 ----
@@ -218,5 +218,3 @@ At the moment the following additional features are planned:
 
 This feature is very new, and will evolve over the coming months based on user feedback. If you want to contribute, or have
 any suggestions/comments head to undertow-dev@lists.jboss.org.
-
-

--- a/content/posts/2015-11-02-Undertow.js-1.0.1.Final.adoc
+++ b/content/posts/2015-11-02-Undertow.js-1.0.1.Final.adoc
@@ -22,15 +22,15 @@ Binary messages are send and received using the JavaScript +ArrayBuffer+ object.
 [source,javascript]
 ----
 $undertow
-    .websocket("/websocket1", ['cdi:myBean', function (myBean, connection) \{
+    .websocket("/websocket1", ['cdi:myBean', function (myBean, connection) {
         connection.send(myBean.getConnectedMessage());
-        connection.onText = function(message) \{
+        connection.onText = function(message) {
             return "echo-" + message;
         }
-        connection.onBinary = function(message) \{
+        connection.onBinary = function(message) {
             return message;
         }
-        connection.onClose = function (message) \{
+        connection.onClose = function (message) {
             print(message.reason + " " + message.code);
         }
     }]);
@@ -49,9 +49,9 @@ To use this we simply need to add a +roles_allowed+ list to a handlers options m
 ----
 $undertow
     .onGet("/rest/endpoint",
-        \{roles_allowed: ['admin', 'user'], headers: \{"content-type": "application/json"}},
-        [function ($exchange) \{
-            return \{message: 'Hello World'};
+        {roles_allowed: ['admin', 'user'], headers: {"content-type": "application/json"}},
+        [function ($exchange) {
+            return {message: 'Hello World'};
         }])
 ----
 
@@ -67,9 +67,9 @@ back. To use this add +transactional: true+ to the methods options map:
 ----
 $undertow
     .onGet("/rest/endpoint",
-        \{transactional: true, headers: \{"content-type": "application/json"}},
-        [function ($exchange) \{
-            return \{message: 'Hello World'};
+        {transactional: true, headers: {"content-type": "application/json"}},
+        [function ($exchange) {
+            return {message: 'Hello World'};
         }])
 ----
 
@@ -88,10 +88,10 @@ handlers declared after the +setDefault+ call:
 ----
 $undertow
     .setDefault('transactional', true)
-    .setDefault('headers' \{"content-type": "application/json"})
+    .setDefault('headers' {"content-type": "application/json"})
     .onGet("/rest/endpoint",
-        [function ($exchange) \{
-            return \{message: 'Hello World'};
+        [function ($exchange) {
+            return {message: 'Hello World'};
         }])
 ----
 
@@ -108,5 +108,3 @@ Going forward
 
 We would welcome any feedback or suggestions. If you want to contribute, or have any comments head to
 undertow-dev@lists.jboss.org.
-
-

--- a/content/posts/2017-09-08-Exploded-deployments.adoc
+++ b/content/posts/2017-09-08-Exploded-deployments.adoc
@@ -10,7 +10,7 @@ author: ehsavoie
 In WildFly there used to be two worlds : one for developers with exploded deployments using a scanner and one for production where artifacts (wars/ears/jars) were deployed. +
 Now those two worlds have collided and you can have exploded deployments without a scanner. +
 And since this is using the management API you get remote access to the content for "free" and of course it works in domain mode. +
-While this new feature is really usefull for tools developers (JBoss Developer Studio will use this in a tech preview, and NetBeans should use it also), YOU can also take advantage of it.
+While this new feature is really useful for tools developers (JBoss Developer Studio will use this in a tech preview, and NetBeans should use it also), YOU can also take advantage of it.
 
 == Creating exploded deployments ==
 
@@ -59,9 +59,10 @@ Let's install and explode a to_be_exploded.war deployment:
 --
 
 This can be achieved via the web console using the explode operation in the menu:
+
 image::exploded_deployments/explode.png[explode]
 
-If you take a look at the $JBOSS_HOME/standalone/content//cf/9918bad9d875ffb20da8747b5dcd15bdab16e0/content/ you will see the exploded war content (it differs from the first example hash has the war file contains META-INF files).
+If you take a look at the `$JBOSS_HOME/standalone/content//cf/9918bad9d875ffb20da8747b5dcd15bdab16e0/content/` you will see the exploded war content (it differs from the first example hash has the war file contains META-INF files).
 [IMPORTANT]
 ====
 Since this content is managed, don't touch it directly by copying file to it manually, always use the Management API (through the jboss-cli or the web console).

--- a/content/posts/2017-09-29-Management-model-referential-integrity.adoc
+++ b/content/posts/2017-09-29-Management-model-referential-integrity.adoc
@@ -16,9 +16,10 @@ to suggest valid values to you as you set up your configuration.
 When you are configuring a WildFly server, a common thing you need to do is configure attributes whose value refers to the name of some other resource.
 A common example of this is a resource that includes a `socket-binding` attribute:
 
-....
+[source]
+-----
 [standalone@localhost:9999 /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=ajp)
-....
+-----
 
 When you do this, it's because the services managed by the resource you are configuring need some capabilities provided by another resource. What you're
 doing is configuring which one to use. But what kind of resource that `socket-binding` attribute refers to may not be obvious, and what the valid values are
@@ -27,24 +28,26 @@ is also not obvious. And before the rollout of improved reference support, if yo
 Here, using WildFly 9 with a config where the previously unused 'ajp' socket binding config had been removed, we try and add an AJP listener
 to the web container:
 
-....
+[source]
+-----
 [standalone@localhost:9990 /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=ajp)
 {
     "outcome" => "failed",
-    "failure-description" => \{"WFLYCTL0180: Services with missing/unavailable dependencies" => ["jboss.undertow.listener.ajp is missing [jboss.binding.ajp]"]},
+    "failure-description" => {"WFLYCTL0180: Services with missing/unavailable dependencies" => ["jboss.undertow.listener.ajp is missing [jboss.binding.ajp]"]},
     "rolled-back" => true
 }
-....
+-----
 
 That error message says nothing about where to go to correct the mistake.
 
 Worse, if you made that mistake when working with a server started in `admin-only` mode, that bad reference would not be detected when you entered it.
 
-....
+[source]
+-----
 [standalone@localhost:9990 /] reload --admin-only=true
 [standalone@localhost:9990 /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=ajp)
 {"outcome" => "success"}
-....
+-----
 
 The configuration would be updated and the problem would only be detected when the server was reloaded or restarted not in `admin-only` mode.
 The server would boot but would not function correctly.
@@ -56,7 +59,8 @@ to proactively ensure that management operations that violate referential integr
 
 The same incorrect operation shown above will now fail immediately, with a message that gives a hint as to where you can configure the missing resource:
 
-....
+[source]
+-----
 [standalone@embedded /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=ajp)
 {
     "outcome" => "failed",
@@ -65,22 +69,24 @@ The same incorrect operation shown above will now fail immediately, with a messa
 		/socket-binding-group=*/socket-binding=*",
     "rolled-back" => true
 }
-....
+-----
 
 The same failure will happen if the server is running in `admin-only` mode (with some exceptions; see "Referential Integrity Checks in an `admin-only` Process"
 below.)
 
 If you think the resource you need already exists, but you're not sure of its name, you can use CLI tab completion to get a list of suggestions:
 
-....
+[source]
+-----
 [standalone@embedded /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=
 http  https  management-http  management-https  txn-recovery-environment  txn-status-manager
 [standalone@embedded /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=
-....
+-----
 
 Once the needed socket binding resource is added, it is available in the tab completion results.
 
-....
+[source]
+-----
 [standalone@embedded /] /socket-binding-group=standard-sockets/socket-binding=ajp:add(port=8009)
 {"outcome" => "success"}
 [standalone@embedded /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=
@@ -88,7 +94,7 @@ ajp                       https                     management-https          tx
 http                      management-http           txn-recovery-environment
 [standalone@embedded /] /subsystem=undertow/server=default-server/ajp-listener=ajp:add(socket-binding=ajp)
 {"outcome" => "success"}
-....
+-----
 
 The HAL console will also suggest valid values by means of a pull-down:
 
@@ -96,7 +102,8 @@ image::choose-socket-binding.png[]
 
 If you try and remove a resource whose capabilities are depended upon by other resources, that will also result in a failed operation:
 
-....
+[source]
+-----
 [standalone@embedded /] /socket-binding-group=standard-sockets/socket-binding=ajp:remove
 {
     "outcome" => "failed",
@@ -104,7 +111,7 @@ If you try and remove a resource whose capabilities are depended upon by other r
 capability 'org.wildfly.undertow.listener.ajp' requires it for attribute 'socket-binding' at address '/subsystem=undertow/server=default-server/ajp-listener=ajp'",
     "rolled-back" => true
 }
-....
+-----
 
 == Referential Integrity Checks in an `admin-only` Process ==
 

--- a/content/posts/2017-10-03-Messaging-features.adoc
+++ b/content/posts/2017-10-03-Messaging-features.adoc
@@ -91,7 +91,7 @@ Once statistics are enabled, the `pooled-connection-factory` resource will have 
 [standalone@localhost:9990 /] /subsystem=messaging-activemq/server=default/pooled-connection-factory=activemq-ra/statistics=pool:read-resource(include-runtime)
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "ActiveCount" => 15,
         "AvailableCount" => 20,
         ...

--- a/content/posts/2017-10-09-Embedded-Host-Controller.adoc
+++ b/content/posts/2017-10-09-Embedded-Host-Controller.adoc
@@ -105,7 +105,7 @@ See link:/news/2015/03/13/Offline-CLI/#classloading[Modular vs Non-Modular Class
     "outcome" => "success",
     "result" => undefined,
     "server-groups" => undefined,
-    "response-headers" => \{"process-state" => "reload-required"}
+    "response-headers" => {"process-state" => "reload-required"}
 }
 ....
 
@@ -192,7 +192,7 @@ When configuring a slave host controller, configure the connection to the domain
     "outcome" => "success",
     "result" => undefined,
     "server-groups" => undefined,
-    "response-headers" => \{"process-state" => "reload-required"}
+    "response-headers" => {"process-state" => "reload-required"}
 }
 ....
 

--- a/content/posts/2018-09-28-Git-History.adoc
+++ b/content/posts/2018-09-28-Git-History.adoc
@@ -88,7 +88,7 @@ You can also use the CLI to list all the snapshots:
 [standalone@localhost:9990 /] :list-snapshots
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "directory" => "",
         "names" => [
             "snapshot : 1st snapshot",

--- a/content/posts/2020-01-03-Custom-Logging-Filter.adoc
+++ b/content/posts/2020-01-03-Custom-Logging-Filter.adoc
@@ -28,18 +28,18 @@ matches the pattern configured on the filter.
 === Example Filter
 [source,java]
 ----
-public class ClassLoaderFilter implements Filter \{
+public class ClassLoaderFilter implements Filter {
 
     @Override
-    public boolean isLoggable(final LogRecord record) \{
+    public boolean isLoggable(final LogRecord record) {
         final ClassLoader cl = getClassLoader();
         String value;
-        if (cl instanceof ModuleClassLoader) \{
+        if (cl instanceof ModuleClassLoader) {
             value = ((ModuleClassLoader) cl).getName();
-        } else \{
+        } else {
             value = cl.toString();
         }
-        if (pattern == null || pattern.matcher(value).matches()) \{
+        if (pattern == null || pattern.matcher(value).matches()) {
             MDC.put("moduleName", value);
             return true;
         }

--- a/content/posts/2020-03-19-Micro_Profile_OpenTracing_Comes_To_WildFly.adoc
+++ b/content/posts/2020-03-19-Micro_Profile_OpenTracing_Comes_To_WildFly.adoc
@@ -54,7 +54,7 @@ If you want to use TCP instead of UDP you need to configure the *sender-endpoint
 [standalone@localhost:9990 /] /subsystem=microprofile-opentracing-smallrye/jaeger-tracer=jaeger-demo:write-attribute(name="sender-endpoint", value="http://localhost:14268/api/traces")
 {
     "outcome" => "success",
-    "response-headers" => \{
+    "response-headers" => {
         "operation-requires-reload" => true,
         "process-state" => "reload-required"
     }
@@ -70,7 +70,7 @@ Let's define this new tracer as the default tracer to be used by WildFly:
 [standalone@localhost:9990 /] /subsystem=microprofile-opentracing-smallrye:write-attribute(name=default-tracer, value=jaeger-demo)
 {
     "outcome" => "success",
-    "response-headers" => \{
+    "response-headers" => {
         "operation-requires-reload" => true,
         "process-state" => "reload-required"
     }

--- a/content/posts/2020-05-11-Using-Qpid-with-WildFly.adoc
+++ b/content/posts/2020-05-11-Using-Qpid-with-WildFly.adoc
@@ -71,7 +71,7 @@ The example consists of two parts :  a _client_ that will send a message to the 
 This is the client code that sends a message:
 [source,java]
 --
-try (Connection connection = factory.createConnection("guest", "guest")) \{
+try (Connection connection = factory.createConnection("guest", "guest")) {
     connection.start();
     Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
     MessageProducer messageProducer = session.createProducer(queue);
@@ -84,16 +84,16 @@ The MDB code is in https://github.com/ehsavoie/qpid-example/blob/master/ejb/src/
 [source, java]
 --
 @Override
-public void onMessage(Message message) \{
+public void onMessage(Message message) {
     try (QueueConnection queueConnection = qcf.createQueueConnection("guest", "guest");
     QueueSession queueSession = queueConnection.createQueueSession(true, Session.SESSION_TRANSACTED);
-    QueueSender queueSender = queueSession.createSender(outQueue)) \{
-    if (message instanceof TextMessage) \{
+    QueueSender queueSender = queueSession.createSender(outQueue)) {
+    if (message instanceof TextMessage) {
         txtMsg = (TextMessage) message;
         msgCnt++;
         queueSender.send(message);
         queueSession.commit();
-    } else \{
+    } else {
         LOG.warnf("MDB[%d] Message of wrong type: %s", mdbID, message.getClass().getName());
     }
 }

--- a/content/posts/2020-06-18-Introducing-the-WildFly-MicroProfile-Reactive-specifications-feature-pack.adoc
+++ b/content/posts/2020-06-18-Introducing-the-WildFly-MicroProfile-Reactive-specifications-feature-pack.adoc
@@ -54,7 +54,7 @@ First we have a method which generates a new price every five seconds:
     private Random random = new Random();
 
     @Outgoing("generated-price")
-    public Flowable<Integer> generate() \{
+    public Flowable<Integer> generate() {
         return Flowable.interval(5, TimeUnit.SECONDS)
                 .map(tick -> random.nextInt(100));
     }
@@ -66,7 +66,7 @@ In this case, we have another method (it can be in another class) annotated with
 ----
     @Incoming("generated-price")
     @Outgoing("to-kafka")
-    public double process(int priceInUsd) \{
+    public double process(int priceInUsd) {
         return priceInUsd * CONVERSION_RATE;
     }
 ----
@@ -109,7 +109,7 @@ Now that we have the converted stream in a `Publisher` instance we can access it
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS) // denotes that server side events (SSE) will be produced
     @SseElementType(MediaType.TEXT_PLAIN) // denotes that the contained data, within this SSE, is just regular text/plain data
-    public Publisher<Double> readThreePrices() \{
+    public Publisher<Double> readThreePrices() {
         // get the next three prices from the price stream
         return ReactiveStreams.fromPublisher(prices)
                 .limit(3)
@@ -131,11 +131,11 @@ Next, let's see how MicroProfile Context Propagation is useful. We will modify t
     @Path("/prices")
     @Produces(MediaType.SERVER_SENT_EVENTS) // denotes that server side events (SSE) will be produced
     @SseElementType(MediaType.TEXT_PLAIN) // denotes that the contained data, within this SSE, is just regular text/plain data
-    public Publisher<Double> readThreePrices() \{
+    public Publisher<Double> readThreePrices() {
         // get the next three prices from the price stream
         return ReactiveStreams.fromPublisher(prices)
                 .limit(3)
-                .map(price -> \{
+                .map(price -> {
                     // Context propagation makes this block inherit the transaction of the caller
                     System.out.println("Storing price: " + price);
                     // store each price before we send them

--- a/content/posts/2020-08-13-Introducing-the-WildFly-GraphQL-feature-pack.adoc
+++ b/content/posts/2020-08-13-Introducing-the-WildFly-GraphQL-feature-pack.adoc
@@ -47,14 +47,14 @@ that retrieves information about all films in the database:
 
 ----
 @GraphQLApi
-public class FilmResource \{
+public class FilmResource {
 
     @Inject
     GalaxyService service;
 
     @Query("allFilms")
     @Description("Get all Films from a galaxy far far away")
-    public List<Film> getAllFilms() \{
+    public List<Film> getAllFilms() {
         return service.getAllFilms();
     }
 }
@@ -62,7 +62,7 @@ public class FilmResource \{
 
 The `Film` class is just a regular JavaBean (getters and setters omitted for brevity):
 ----
-public class Film \{
+public class Film {
     private String title;
     private Integer episodeID;
     private String director;
@@ -72,8 +72,8 @@ public class Film \{
 
 In such case, if the GraphQL client calls the following query:
 ----
-query allFilms \{
-  allFilms \{
+query allFilms {
+  allFilms {
     title
     releaseDate
   }
@@ -83,17 +83,17 @@ query allFilms \{
 The client will get back the requested data about all the films in the database (in our case, we only included episodes 4, 5 and 6!):
 ----
 {
-  "data": \{
+  "data": {
     "allFilms": [
-      \{
+      {
         "title": "A New Hope",
         "releaseDate": "1977-05-25"
       },
-      \{
+      {
         "title": "The Empire Strikes Back",
         "releaseDate": "1980-05-21"
       },
-      \{
+      {
         "title": "Return Of The Jedi",
         "releaseDate": "1983-05-25"
       }

--- a/content/posts/2020-10-27-wildfly-operator-0.4.1-released.adoc
+++ b/content/posts/2020-10-27-wildfly-operator-0.4.1-released.adoc
@@ -43,7 +43,7 @@ To illustrate this feature, I wrote a very simple MicroProfile application that 
 ----
 @Path("/")
 @ApplicationScoped
-public class AppEndpoint \{
+public class AppEndpoint {
 
     @Inject
     @ConfigProperty(name = "greetings", defaultValue = "Hello")
@@ -51,7 +51,7 @@ public class AppEndpoint \{
 
     @GET
     @Produces({ "application/json" })
-    public String getText() \{
+    public String getText() {
         String text = "{\"text\":\"" + greetings + ", World!\"}";
         return text;
     }
@@ -93,7 +93,7 @@ To show how we can seamlessly upgrade to a new version of this application, I cr
 
 [source,java]
 ----
-public String getText() \{
+public String getText() {
     String text = "{\"text\":\"" + (greetings + ", World!").toUpperCase() + "\"}";
     return text;
 }

--- a/content/posts/2021-01-14-batch-processing-stop-job-step.adoc
+++ b/content/posts/2021-01-14-batch-processing-stop-job-step.adoc
@@ -42,14 +42,14 @@ different thread. And the batchlet class should be implemented to properly handl
 [source,java]
 ----
 @Named
-public class Batchlet1 implements Batchlet \{
+public class Batchlet1 implements Batchlet {
     private final AtomicBoolean toStop = new AtomicBoolean();
 
     @Override
-    public String process() throws Exception \{
+    public String process() throws Exception {
         String exitStatus = "BATCHLET1_COMPLETED";
-        while (true) \{
-            if (toStop.get()) \{
+        while (true) {
+            if (toStop.get()) {
                 exitStatus = "BATCHLET1_STOPPED";
                 break;
             }
@@ -59,7 +59,7 @@ public class Batchlet1 implements Batchlet \{
     }
 
     @Override
-    public void stop() throws Exception \{
+    public void stop() throws Exception {
         toStop.set(true);
     }
 }
@@ -96,7 +96,7 @@ restarted from where it left off.
 /deployment=numbers-chunk.war/subsystem=batch-jberet/job=numbers/execution=1:read-resource(include-runtime, recursive)
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "batch-status" => "STOPPED",
         "create-time" => "2020-10-29T19:33:13.843-0400",
         "end-time" => "2020-10-29T19:33:30.258-0400",
@@ -159,12 +159,12 @@ Once the batchlet is stopped this way, the batch status of the step will be `COM
 [source,java]
 ----
 @Named
-public class Batchlet1 implements Batchlet \{
+public class Batchlet1 implements Batchlet {
     @Override
-    public String process() throws Exception \{
+    public String process() throws Exception {
         String exitStatus = "BATCHLET1_COMPLETED";
-        while (true) \{
-            if (shouldStop()) \{
+        while (true) {
+            if (shouldStop()) {
                 exitStatus = "BATCHLET1_STOPPED";
                 break;
             }
@@ -174,12 +174,12 @@ public class Batchlet1 implements Batchlet \{
         return exitStatus;
     }
 
-    private boolean shouldStop() \{
+    private boolean shouldStop() {
         return Boolean.getBoolean("job1.batchlet1.stop");
     }
 
     @Override
-    public void stop() throws Exception \{
+    public void stop() throws Exception {
         // implement stop() method to respond to incoming request
         // to stop this batchlet step and entire job execution
     }

--- a/content/posts/2021-10-14-MicroProfile-Reactive-Messaging-2.0-in-WildFly-25.adoc
+++ b/content/posts/2021-10-14-MicroProfile-Reactive-Messaging-2.0-in-WildFly-25.adoc
@@ -32,7 +32,7 @@ The core of the application is a https://github.com/kabir/blog-reactive-messagin
 
 [source, java]
 ----
-public class MessagingFilter extends HttpFilter \{
+public class MessagingFilter extends HttpFilter {
     @Inject
     @Channel("from-filter")
     Emitter<PageVisit> messagingEmitter;
@@ -42,7 +42,7 @@ FIrst we have field injected via CDI of type `Emitter`, called `messagingEmitter
 ----
 
     @Override
-    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException \{
+    public void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String user = getUsername(request);
         String address = request.getRemoteAddr();
         String page = Paths.get(request.getRequestURI()).getFileName().toString();
@@ -67,9 +67,9 @@ Getting the user name is simulated in the following method which randomly choose
 [source, java]
 ----
 
-    private String getUsername(HttpServletRequest servletRequest) \{
+    private String getUsername(HttpServletRequest servletRequest) {
         // Pretend we're looking up the authenticated user
-        switch ((int)Math.round(Math.random() * 3)) \{
+        switch ((int)Math.round(Math.random() * 3)) {
             case 0:
                 return "bob";
             case 1:
@@ -89,15 +89,15 @@ Next, we have an `ApplicationScoped` CDI bean called https://github.com/kabir/bl
 [source, java]
 ----
 @ApplicationScoped
-public class MessagingBean \{
+public class MessagingBean {
     @Inject
     @Channel("special")
     Emitter<PageVisit> special;
 
     @Incoming("from-filter")
     @Outgoing("kafka-visits")
-    public Message<PageVisit> fromFilter(PageVisit pageVisit) \{
-        if (pageVisit.getPage().equals("3.html")) \{
+    public Message<PageVisit> fromFilter(PageVisit pageVisit) {
+        if (pageVisit.getPage().equals("3.html")) {
             special.send(pageVisit);
         }
         Message<PageVisit> msg = Message.of(pageVisit);
@@ -111,7 +111,7 @@ public class MessagingBean \{
     }
 
     @Incoming("special")
-    public void special(PageVisit pageVisit) \{
+    public void special(PageVisit pageVisit) {
         System.out.println("===> " + pageVisit.getUserName() + " visited " + pageVisit.getPage());
     }
 }
@@ -174,15 +174,15 @@ The https://github.com/kabir/blog-reactive-messaging-2.0/blob/master/streams/src
 [source, java]
 ----
 
-    public static void main(String[] args) throws Exception \{
-        try (DataStoreWrapper dsw = new DataStoreWrapper()) \{
+    public static void main(String[] args) throws Exception {
+        try (DataStoreWrapper dsw = new DataStoreWrapper()) {
             dsw.init();
             Map<String, String> lastPagesByUser = Collections.emptyMap();
-            try \{
+            try {
                 dsw.readLastVisitedPageByUsers();
-            } catch (InvalidStateStoreException e) \{
+            } catch (InvalidStateStoreException e) {
             }
-            if (lastPagesByUser.size() == 0) \{
+            if (lastPagesByUser.size() == 0) {
                 // It seems that although the stream is reported as RUNNING
                 // in dsw.init() it still needs some time to settle. Until that
                 // happens there is no data or we get InvalidStateStoreException
@@ -201,7 +201,7 @@ Looking at the https://github.com/kabir/blog-reactive-messaging-2.0/blob/master/
 [source, java]
 ----
 @ApplicationScoped
-public class DataStoreWrapper implements Closeable \{
+public class DataStoreWrapper implements Closeable {
     private volatile KafkaStreams streams;
 ----
 We will initialise this streams instance in the `init()` method below.
@@ -209,14 +209,14 @@ We will initialise this streams instance in the `init()` method below.
 ----
 
     @Inject
-    private ConfigSupplier configSupplier = new ConfigSupplier() \{
+    private ConfigSupplier configSupplier = new ConfigSupplier() {
         @Override
-        public String getBootstrapServers() \{
+        public String getBootstrapServers() {
             return "localhost:9092";
         }
 
         @Override
-        public String getTopicName() \{
+        public String getTopicName() {
             return "page-visits";
         }
     };
@@ -225,15 +225,15 @@ The `configSupplier` field is inititalised to an implementation of https://githu
 [source, java]
 ----
 
-    DataStoreWrapper() \{
+    DataStoreWrapper() {
     }
 ----
 Next, we will take a look at the `init()` method where we set up the ability to query the stream.
 [source, java]
 ----
     @PostConstruct
-    void init() \{
-        try \{
+    void init() {
+        try {
 
             Properties props = new Properties();
             props.put(StreamsConfig.APPLICATION_ID_CONFIG, "streams-pipe");
@@ -265,9 +265,9 @@ Now we create a https://kafka.apache.org/28/javadoc/org/apache/kafka/streams/kst
 ----
             final CountDownLatch startLatch = new CountDownLatch(1);
             final AtomicReference<KafkaStreams.State> state = new AtomicReference<>();
-            streams.setStateListener((newState, oldState) -> \{
+            streams.setStateListener((newState, oldState) -> {
                 state.set(newState);
-                switch (newState) \{
+                switch (newState) {
                     case RUNNING:
                     case ERROR:
                     case PENDING_SHUTDOWN:
@@ -278,15 +278,15 @@ Now we create a https://kafka.apache.org/28/javadoc/org/apache/kafka/streams/kst
             startLatch.await(10, TimeUnit.SECONDS);
             System.out.println("Stream started");
 
-            if (state.get() != KafkaStreams.State.RUNNING) \{
+            if (state.get() != KafkaStreams.State.RUNNING) {
                 throw new IllegalStateException();
             }
 ----
 Finally, we start the stream and wait for it to start.
 [source, java]
 ----
-        } catch (Exception e) \{
-            if (this.streams != null) \{
+        } catch (Exception e) {
+            if (this.streams != null) {
                 this.streams.close();
             }
             throw new RuntimeException(e);
@@ -298,7 +298,7 @@ The `readLastVisitedPageByUsers()` method uses the `StateStore` we set up earlie
 [source, java]
 ----
 
-    public Map<String, String> readLastVisitedPageByUsers() \{
+    public Map<String, String> readLastVisitedPageByUsers() {
         StoreQueryParameters<ReadOnlyKeyValueStore<String, PageVisit>> sqp = StoreQueryParameters.fromNameAndType("test-store", QueryableStoreTypes.keyValueStore());
         final ReadOnlyKeyValueStore<String, PageVisit> store = this.streams.store(sqp);
 
@@ -309,7 +309,7 @@ The `readLastVisitedPageByUsers()` method uses the `StateStore` we set up earlie
     }
 
     @PreDestroy
-    public void close() \{
+    public void close() {
         this.streams.close();
     }
 
@@ -341,17 +341,17 @@ We then create an implementation of the https://github.com/kabir/blog-reactive-m
 [source, java]
 ----
 @ApplicationScoped
-public class MpConfigConfigSupplier implements ConfigSupplier \{
+public class MpConfigConfigSupplier implements ConfigSupplier {
     @Inject
     Config config;
 
     @Override
-    public String getBootstrapServers() \{
+    public String getBootstrapServers() {
         return config.getValue("kafka.bootstrap.servers", String.class);
     }
 
     @Override
-    public String getTopicName() \{
+    public String getTopicName() {
         return config.getValue("kafka.topic", String.class);
     }
 }
@@ -360,11 +360,11 @@ Our https://github.com/kabir/blog-reactive-messaging-2.0/blob/master/streams/src
 [source, java]
 ----
 @ApplicationScoped
-public class DataStoreWrapper implements Closeable \{
+public class DataStoreWrapper implements Closeable {
     private volatile KafkaStreams streams;
 
     @Inject
-    private ConfigSupplier configSupplier = new ConfigSupplier() \{
+    private ConfigSupplier configSupplier = new ConfigSupplier() {
         // -- SNIP --
         // This implementation gets replaced by the injected MpConfigConfigSupplier
 ----
@@ -374,13 +374,13 @@ In order to be able to call this from a client, we add a simple https://github.c
 ----
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
-public class StreamsEndpoint \{
+public class StreamsEndpoint {
     @Inject
     DataStoreWrapper wrapper;
 
     @GET
     @Path("/last-visited")
-    public Map<String, String> getLastVisited() \{
+    public Map<String, String> getLastVisited() {
         return wrapper.readLastVisitedPageByUsers();
     }
 }

--- a/content/posts/2022-08-19-RHOSAK.adoc
+++ b/content/posts/2022-08-19-RHOSAK.adoc
@@ -190,9 +190,9 @@ When deploying an application into OpenShift using Helm, it will look for a Mave
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-jar-maven-plugin</artifactId>
-                <version>$\{version.wildfly-jar.maven.plugin}</version>
+                <version>${version.wildfly-jar.maven.plugin}</version>
                 <configuration>
-                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#$\{version.server.bootable-jar}</feature-pack-location>
+                    <feature-pack-location>wildfly@maven(org.jboss.universe:community-universe)#${version.server.bootable-jar}</feature-pack-location>
                     <layers>
                         <layer>cloud-server</layer>
                         <layer>microprofile-reactive-messaging-kafka</layer>
@@ -235,19 +235,19 @@ The plugin will also run the link:https://github.com/kabir/blog-mp-reactive-mess
 ----
 echo "Adding the 'rhoas' secret volume mount as a MicroProfile Config source..."
 
-/subsystem=microprofile-config-smallrye/config-source=rhosak-binding:add(dir=\{path=/etc/config/rhoas})
+/subsystem=microprofile-config-smallrye/config-source=rhosak-binding:add(dir={path=/etc/config/rhoas})
 
 echo "Adding the MicroProfile Config entries mapping the secret values..."
 
 /subsystem=microprofile-config-smallrye/\
 config-source=reactive-messaging-properties:add(properties={\
-mp.messaging.connector.smallrye-kafka.bootstrap.servers=$\{KAFKA_HOST},\
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${KAFKA_HOST},\
 mp.messaging.connector.smallrye-kafka.security.protocol=SASL_SSL,\
 mp.messaging.connector.smallrye-kafka.sasl.mechanism=PLAIN,\
 mp.messaging.connector.smallrye-kafka.sasl.jaas.config="\n\
 org.apache.kafka.common.security.plain.PlainLoginModule required\n\
-username=\"$\{RHOAS_SERVICE_ACCOUNT_CLIENT_ID}\"\n\
-password=\"$\{RHOAS_SERVICE_ACCOUNT_CLIENT_SECRET}\";"\
+username=\"${RHOAS_SERVICE_ACCOUNT_CLIENT_ID}\"\n\
+password=\"${RHOAS_SERVICE_ACCOUNT_CLIENT_SECRET}\";"\
 }, ordinal=500)
 ----
 First of all it is worth noting that we don't need to enable the MicroProfile Reactive Messaging and Reactive Streams Operators extensions/subsystems in this case. This is unlike when we were using the downloaded WildFly zip archive earlier. This is because when a server is provisioned using Galleon, the `microprofile-reactive-messaging-kafka` layer takes care of that for us.

--- a/content/posts/2023-01-10-ansible-wildfly.adoc
+++ b/content/posts/2023-01-10-ansible-wildfly.adoc
@@ -95,7 +95,7 @@ Here is the playbook we'll use to deploy our clusters. Its content is relatively
     - role: wildfly_install
   tasks:
 
-    - name: "Set up for WildFly instance \{{ item }}."
+    - name: "Set up for WildFly instance {{ item }}."
       ansible.builtin.include_role:
         name: wildfly_systemd
       vars:
@@ -446,7 +446,7 @@ In our case, we will use the jboss_cli.yml task file, which encapsulates the run
 ----
 …
   post_tasks:
-      - name: "Ensures webapp \{{ app.name }} has been retrieved from \{{ app.url }}."
+      - name: "Ensures webapp {{ app.name }} has been retrieved from {{ app.url }}."
         ansible.builtin.get_url:
           url: "{{ app.url }}"
           dest: "{{ wildfly_install_workdir }}/{{ app.name }}"
@@ -457,7 +457,7 @@ In our case, we will use the jboss_cli.yml task file, which encapsulates the run
           tasks_from: jboss_cli.yml
         vars:
           jboss_home: "{{ wildfly_home }}"
-          query: "'deploy --force \{{ wildfly_install_workdir }}/{{ app.name }}'"
+          query: "'deploy --force {{ wildfly_install_workdir }}/{{ app.name }}'"
           jboss_cli_controller_port: "{{ item }}"
         loop:
           - 9990

--- a/content/posts/2023-05-24-MicroProfile-LRA.adoc
+++ b/content/posts/2023-05-24-MicroProfile-LRA.adoc
@@ -54,7 +54,7 @@ to be explitcly enabled either in the configuration XML or by using CLI operatio
 [standalone@localhost:9990 /] /subsystem=microprofile-lra-coordinator:add
 {
     "outcome" => "success",
-    "response-headers" => \{
+    "response-headers" => {
         "operation-requires-reload" => true,
         "process-state" => "reload-required"
     }
@@ -66,7 +66,7 @@ to be explitcly enabled either in the configuration XML or by using CLI operatio
 [standalone@localhost:9990 /] /subsystem=microprofile-lra-participant:add
 {
     "outcome" => "success",
-    "response-headers" => \{
+    "response-headers" => {
         "operation-requires-reload" => true,
         "process-state" => "reload-required"
     }
@@ -95,7 +95,7 @@ or 5xx error HTTP status codes the LRA will be cancelled instead.
 @LRA
 @GET
 @Path("/doInLRA")
-public Response doInLRA(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) \{
+public Response doInLRA(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) {
     LOG.info("Work LRA ID = " + lraId);
     ...
 ----
@@ -107,7 +107,7 @@ When LRA closes successfully, the LRA coordinator calls the completion callback 
 @Complete
 @PUT
 @Path("/complete")
-public Response complete(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) \{
+public Response complete(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) {
     LOG.info("Complete ID = " + lraId);
     ...
 ----
@@ -119,7 +119,7 @@ Or, in the case of LRA cancel, the compensation callback will be invoked instead
 @Compensate
 @PUT
 @Path("/compensate")
-public Response compensate(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) \{
+public Response compensate(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) String lraId) {
     LOG.info("Compensate ID = " + lraId);
     ...
 ----

--- a/content/posts/2023-06-12-grpc-subsystem.adoc
+++ b/content/posts/2023-06-12-grpc-subsystem.adoc
@@ -65,18 +65,18 @@ project (https://github.com/wildfly-extras/wildfly-grpc-feature-pack):
     package helloworld;
 
     // The greeting service definition.
-    service Greeter \{
+    service Greeter {
         // Sends a greeting
-        rpc SayHello (HelloRequest) returns (HelloReply) \{}
+        rpc SayHello (HelloRequest) returns (HelloReply) {}
     }
 
     // The request message containing the user's name.
-    message HelloRequest \{
+    message HelloRequest {
         string name = 1;
     }
 
     // The response message containing the greetings
-    message HelloReply \{
+    message HelloReply {
         string message = 1;
     }
 ----
@@ -115,7 +115,7 @@ matter of overriding each such method with real content, as in
 [source,java]
 ----
    @Override
-   public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) \{
+   public void sayHello(HelloRequest request, StreamObserver<HelloReply> responseObserver) {
       String name = request.getName();
       String message = "Hello " + name;
       responseObserver.onNext(HelloReply.newBuilder().setMessage(message).build());

--- a/content/posts/2023-11-30-intro-to-the-various-java-based-k8s-oc-tools.adoc
+++ b/content/posts/2023-11-30-intro-to-the-various-java-based-k8s-oc-tools.adoc
@@ -311,10 +311,10 @@ It works as a JUnit extension that take cares of the image deployment to k8s/ope
 
 [source,java]
 ----
-private void startResourcesInList(ExtensionContext context, KubernetesResource kubernetesResource, KubernetesList resourceList) \{
+private void startResourcesInList(ExtensionContext context, KubernetesResource kubernetesResource, KubernetesList resourceList) {
         KubernetesClient client = getKubernetesClient(context);
         resourceList.getItems().stream()
-                .forEach(i -> \{
+                .forEach(i -> {
                     client.resourceList(i).createOrReplace();
                     System.out.println("Created: " + i.getKind() + " name:" + i.getMetadata().getName() + ".");
                 });
@@ -325,78 +325,78 @@ private void startResourcesInList(ExtensionContext context, KubernetesResource k
                 i instanceof ReplicationController).collect(Collectors.toList());
         long started = System.currentTimeMillis();
         System.out.println("Waiting until ready (" + kubernetesResource.readinessTimeout() + " ms)...");
-        try \{
+        try {
             waitUntilCondition(context, waitables, i -> Readiness.getInstance().isReady(i), kubernetesResource.readinessTimeout(),
                     TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) \{
+        } catch (InterruptedException e) {
             throw new IllegalStateException("Gave up waiting after " + kubernetesResource.readinessTimeout());
         }
         long ended = System.currentTimeMillis();
         System.out.println("Waited: " + (ended - started) + " ms.");
         //Display the item status
         waitables.stream().map(r -> client.resource(r).fromServer().get())
-                .forEach(i -> \{
-                    if (!Readiness.getInstance().isReady(i)) \{
+                .forEach(i -> {
+                    if (!Readiness.getInstance().isReady(i)) {
                         readinessFailed(context);
                         System.out.println(i.getKind() + ":" + i.getMetadata().getName() + " not ready!");
                     }
                 });
 
 
-        if (hasReadinessFailed(context)) \{
+        if (hasReadinessFailed(context)) {
             throw new IllegalStateException("Readiness Failed");
-        } else if (kubernetesResource.additionalResourcesCreated().length > 0) \{
+        } else if (kubernetesResource.additionalResourcesCreated().length > 0) {
             long end = started + kubernetesResource.readinessTimeout();
             Map<String, ResourceGetter> resourceGetters = new HashMap<>();
-            for (org.wildfly.test.cloud.common.Resource resource : kubernetesResource.additionalResourcesCreated()) \{
-                if (resourceGetters.put(resource.name(), ResourceGetter.create(client, resource)) != null) \{
+            for (org.wildfly.test.cloud.common.Resource resource : kubernetesResource.additionalResourcesCreated()) {
+                if (resourceGetters.put(resource.name(), ResourceGetter.create(client, resource)) != null) {
                     throw new IllegalStateException(resource.name() + " appears more than once in additionalResourcesCreated()");
                 }
             }
 
             Map<String, HasMetadata> additionalWaitables = new HashMap<>();
-            while (System.currentTimeMillis() < end) \{
-                for (Map.Entry<String, ResourceGetter> entry : resourceGetters.entrySet()) \{
-                    if (!additionalWaitables.containsKey(entry.getKey())) \{
+            while (System.currentTimeMillis() < end) {
+                for (Map.Entry<String, ResourceGetter> entry : resourceGetters.entrySet()) {
+                    if (!additionalWaitables.containsKey(entry.getKey())) {
                         ResourceGetter getter = entry.getValue();
                         HasMetadata hasMetadata = getter.getResource();
-                        if (hasMetadata != null) \{
+                        if (hasMetadata != null) {
                             additionalWaitables.put(entry.getKey(), hasMetadata);
                         }
                     }
                 }
-                if (additionalWaitables.size() == resourceGetters.size()) \{
+                if (additionalWaitables.size() == resourceGetters.size()) {
                     break;
                 }
-                try \{
+                try {
                     Thread.sleep(1000);
-                } catch (InterruptedException e) \{
+                } catch (InterruptedException e) {
                     Thread.interrupted();
                     throw new IllegalStateException(e);
                 }
             }
 
-            if (additionalWaitables.size() != resourceGetters.size()) \{
+            if (additionalWaitables.size() != resourceGetters.size()) {
                 throw new IllegalStateException("Could not start all items in " + kubernetesResource.readinessTimeout());
             }
 
 
-            try \{
+            try {
                 waitUntilCondition(context, additionalWaitables.values(), i -> Readiness.getInstance().isReady(i), end - System.currentTimeMillis(),
                         TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) \{
+            } catch (InterruptedException e) {
                 throw new IllegalStateException("Gave up waiting after " + (System.currentTimeMillis() - started));
             }
 
             waitables.stream().map(r -> client.resource(r).fromServer().get())
-                    .forEach(i -> \{
-                        if (!Readiness.getInstance().isReady(i)) \{
+                    .forEach(i -> {
+                        if (!Readiness.getInstance().isReady(i)) {
                             readinessFailed(context);
                             System.out.println(i.getKind() + ":" + i.getMetadata().getName() + " not ready!");
                         }
                     });
 
-            if (hasReadinessFailed(context)) \{
+            if (hasReadinessFailed(context)) {
                 throw new IllegalStateException("Readiness Failed");
             }
         }
@@ -407,26 +407,26 @@ Here is the method that will be called after the test running:
 
 [source,java]
 ----
-private void cleanupKubernetesResources(ExtensionContext context, WildFlyIntegrationTestConfig config, WildFlyTestContext testContext) \{
-        if (config.getKubernetesResources().isEmpty()) \{
+private void cleanupKubernetesResources(ExtensionContext context, WildFlyIntegrationTestConfig config, WildFlyTestContext testContext) {
+        if (config.getKubernetesResources().isEmpty()) {
             return;
         }
 
         List<KubernetesResource> kubernetesResources = config.getKubernetesResources();
-        for (int i = kubernetesResources.size() - 1 ; i >= 0 ; i--) \{
+        for (int i = kubernetesResources.size() - 1 ; i >= 0 ; i--) {
             KubernetesResource kubernetesResource = kubernetesResources.get(i);
             KubernetesList resourceList = null;
-            try \{
-                try (InputStream in = getLocalOrRemoteKubernetesResourceInputStream(kubernetesResource.definitionLocation())) \{
+            try {
+                try (InputStream in = getLocalOrRemoteKubernetesResourceInputStream(kubernetesResource.definitionLocation())) {
                     resourceList = Serialization.unmarshalAsList(in);
                 }
-            } catch (Exception e) \{
+            } catch (Exception e) {
                 throw toRuntimeException(e);
             }
 
             List<HasMetadata> list = resourceList.getItems();
             Collections.reverse(list);
-            list.stream().forEach(r -> \{
+            list.stream().forEach(r -> {
                 System.out.println("Deleting: " + r.getKind() + " name:" + r.getMetadata().getName() + ". Deleted:"
                         + getKubernetesClient(context).resource(r).cascading(true).delete());
             });

--- a/content/posts/2024-01-18-ansible-wildfly.adoc
+++ b/content/posts/2024-01-18-ansible-wildfly.adoc
@@ -94,7 +94,7 @@ Here is the playbook we'll use to deploy our clusters. Its content is relatively
     - role: wildfly_install
   tasks:
 
-    - name: "Set up for WildFly instance \{{ item }}."
+    - name: "Set up for WildFly instance {{ item }}."
       ansible.builtin.include_role:
         name: wildfly_systemd
       vars:
@@ -153,7 +153,7 @@ skipping: [localhost]
 TASK [middleware_automation.wildfly.wildfly_install : Validate patch version for offline installs] ***
 skipping: [localhost]
 
-TASK [middleware_automation.wildfly.wildfly_install : Validate existing additional zipfiles \{{ eap_archive_filename }} for offline installs] ***
+TASK [middleware_automation.wildfly.wildfly_install : Validate existing additional zipfiles {{ eap_archive_filename }} for offline installs] ***
 skipping: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_install : Check that required packages list has been provided.] ***
@@ -276,7 +276,7 @@ ok: [localhost]
 TASK [Ensure firewalld configuration allows server port (if enabled).] *********
 skipping: [localhost]
 
-TASK [Set up for WildFly instance \{{ item }}.] *********************************
+TASK [Set up for WildFly instance {{ item }}.] *********************************
 
 TASK [middleware_automation.wildfly.wildfly_systemd : Validating arguments against arg spec 'main'] ***
 ok: [localhost]
@@ -323,7 +323,7 @@ TASK [middleware_automation.wildfly.wildfly_systemd : Set base directory for ins
 ok: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_systemd : Check arguments] *********
-ok: [localhost] => \{
+ok: [localhost] => {
     "changed": false,
     "msg": "All assertions passed"
 }
@@ -430,7 +430,7 @@ TASK [middleware_automation.wildfly.wildfly_systemd : Set base directory for ins
 ok: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_systemd : Check arguments] *********
-ok: [localhost] => \{
+ok: [localhost] => {
     "changed": false,
     "msg": "All assertions passed"
 }
@@ -537,7 +537,7 @@ TASK [middleware_automation.wildfly.wildfly_systemd : Set base directory for ins
 ok: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_systemd : Check arguments] *********
-ok: [localhost] => \{
+ok: [localhost] => {
     "changed": false,
     "msg": "All assertions passed"
 }
@@ -658,7 +658,7 @@ In our case, we will use the jboss_cli.yml task file, which encapsulates the run
 ----
 …
   post_tasks:
-      - name: "Ensures webapp \{{ app.name }} has been retrieved from \{{ app.url }}."
+      - name: "Ensures webapp {{ app.name }} has been retrieved from {{ app.url }}."
         ansible.builtin.get_url:
           url: "{{ app.url }}"
           dest: "{{ wildfly_install_workdir }}/{{ app.name }}"
@@ -669,7 +669,7 @@ In our case, we will use the jboss_cli.yml task file, which encapsulates the run
           tasks_from: jboss_cli.yml
         vars:
           jboss_home: "{{ wildfly_home }}"
-          query: "'deploy --force \{{ wildfly_install_workdir }}/{{ app.name }}'"
+          query: "'deploy --force {{ wildfly_install_workdir }}/{{ app.name }}'"
           jboss_cli_controller_port: "{{ item }}"
         loop:
           - 9990

--- a/content/posts/2024-09-10-ansible-yaml-wildfly.adoc
+++ b/content/posts/2024-09-10-ansible-yaml-wildfly.adoc
@@ -101,8 +101,8 @@ To verify that everything works as expected and that Ansible is ready to be used
 [source, bash]
 ----
 # ansible -m setup -i inventory all
-localhost | SUCCESS => \{
-    "ansible_facts": \{
+localhost | SUCCESS => {
+    "ansible_facts": {
 ...
 ----
 
@@ -164,7 +164,7 @@ skipping: [localhost]
 TASK [middleware_automation.wildfly.wildfly_install : Validate patch version for offline installs] ***
 skipping: [localhost]
 
-TASK [middleware_automation.wildfly.wildfly_install : Validate existing additional zipfiles \{{ eap_archive_filename }} for offline installs] ***
+TASK [middleware_automation.wildfly.wildfly_install : Validate existing additional zipfiles {{ eap_archive_filename }} for offline installs] ***
 skipping: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_install : Validate node identifier length] ***
@@ -204,7 +204,7 @@ TASK [middleware_automation.wildfly.wildfly_install : Check if work directory /o
 ok: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_install : Check if work directory /opt/ is readable] ***
-ok: [localhost] => \{
+ok: [localhost] => {
     "changed": false,
     "msg": "Archive directory /opt/ is readable"
 }
@@ -216,7 +216,7 @@ TASK [middleware_automation.wildfly.wildfly_install : Check if archive directory
 ok: [localhost]
 
 TASK [middleware_automation.wildfly.wildfly_install : Check if archive directory /opt/ is readable] ***
-ok: [localhost] => \{
+ok: [localhost] => {
     "changed": false,
     "msg": "Archive directory /opt/ is readable"
 }
@@ -523,7 +523,7 @@ FirstQueue is actually a legacy system, employed by a few, non-critical older ap
 /subsystem=messaging-activemq/server=default/jms-queue=FirstQueue:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "durable" => false,
         "entries" => ["java:/jms/queue/first"],
         "legacy-entries" => ["java:/jms/legacy/queue/old"],
@@ -626,8 +626,8 @@ As shown above, the collection provides a generic role that takes care of creati
 postgres_driver_version: 9.4.1212
 mariadb_driver_version: 3.2.0
 jdbc_drivers:
-    - \{ version: "{{ postgres_driver_version }}", name: 'org.postgresql', jar_file: "postgresql-{{ postgres_driver_version }}.jar", url: "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/{{ postgres_driver_version }}/postgresql-{{ postgres_driver_version }}.jar" }
-    - \{ version: "{{ mariadb_driver_version }}", name: 'org.mariadb', jar_file: "mariadb-java-client-{{ mariadb_driver_version }}.jar", url: "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/{{ mariadb_driver_version }}/mariadb-java-client-{{ mariadb_driver_version }}.jar" }
+    - { version: "{{ postgres_driver_version }}", name: 'org.postgresql', jar_file: "postgresql-{{ postgres_driver_version }}.jar", url: "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/{{ postgres_driver_version }}/postgresql-{{ postgres_driver_version }}.jar" }
+    - { version: "{{ mariadb_driver_version }}", name: 'org.mariadb', jar_file: "mariadb-java-client-{{ mariadb_driver_version }}.jar", url: "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/{{ mariadb_driver_version }}/mariadb-java-client-{{ mariadb_driver_version }}.jar" }
 ----
 
 *Note:* _The Ansible collection for WildFly comes with a default template to generate the `module.xml` of a custom module. Obviously, this template might not be a good fit for ALL the drivers that users may have to install in a WildFly setup. For this reason, the template itself can easily be replaced by another one, provided by the user._
@@ -654,12 +654,12 @@ As we already have a datastructure with most of the required information, we are
 ----
 ...
     datasources:
-      \{% if jdbc_drivers is defined and jdbc_drivers | length > 0 %}jdbc-driver:
+      {% if jdbc_drivers is defined and jdbc_drivers | length > 0 %}jdbc-driver:
 {% for driver in jdbc_drivers %}
-        \{{ driver.name | regex_replace('^org.', '') }}:
-          driver-name: \{{ driver.name | regex_replace('^org.', '') }}
-          driver-xa-datasource-class-name: \{{ driver.class_name }}
-          driver-module-name: \{{ driver.name }}
+        {{ driver.name | regex_replace('^org.', '') }}:
+          driver-name: {{ driver.name | regex_replace('^org.', '') }}
+          driver-xa-datasource-class-name: {{ driver.class_name }}
+          driver-module-name: {{ driver.name }}
 {% endfor %}
 {% endif %}
 ----
@@ -671,8 +671,8 @@ The variable provided by the default `playbook` does not contain the JDBC driver
 [source, yaml]
 ----
 jdbc_drivers:
-  - \{ version: "{{ postgres_driver_version }}", name: 'org.postgresql', jar_file: "postgresql-{{ postgres_driver_version }}.jar", url: "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/{{ postgres_driver_version }}/postgresql-{{ postgres_driver_version }}.jar", class_name: 'org.postgresql.xa.PGXADataSource' }
-  - \{ version: "{{ mariadb_driver_version }}", name: 'org.mariadb', jar_file: "mariadb-java-client-{{ mariadb_driver_version }}.jar", url: "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/{{ mariadb_driver_version }}/mariadb-java-client-{{ mariadb_driver_version }}.jar", class_name: 'org.mariadb.jdbc.Driver' }
+  - { version: "{{ postgres_driver_version }}", name: 'org.postgresql', jar_file: "postgresql-{{ postgres_driver_version }}.jar", url: "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/{{ postgres_driver_version }}/postgresql-{{ postgres_driver_version }}.jar", class_name: 'org.postgresql.xa.PGXADataSource' }
+  - { version: "{{ mariadb_driver_version }}", name: 'org.mariadb', jar_file: "mariadb-java-client-{{ mariadb_driver_version }}.jar", url: "https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/{{ mariadb_driver_version }}/mariadb-java-client-{{ mariadb_driver_version }}.jar", class_name: 'org.mariadb.jdbc.Driver' }
 ----
 
 We can now run again the `playbook` and simply check, after it ran successfully, that the drivers have been properly added:
@@ -682,7 +682,7 @@ We can now run again the `playbook` and simply check, after it ran successfully,
 [standalone@localhost:9990 /] /subsystem=datasources/jdbc-driver=mariadb:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "deployment-name" => undefined,
         "driver-class-name" => undefined,
         "driver-datasource-class-name" => undefined,
@@ -699,7 +699,7 @@ We can now run again the `playbook` and simply check, after it ran successfully,
 [standalone@localhost:9990 /] /subsystem=datasources/jdbc-driver=postgresql:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "deployment-name" => undefined,
         "driver-class-name" => undefined,
         "driver-datasource-class-name" => undefined,
@@ -728,10 +728,10 @@ wildfly-configuration:
         DefaultDS:
           enabled: true
           jndi-name: java:jboss/datasources/DefaultDS
-          max-pool-size: \{{ default_ds_max_size }}
-          min-pool-size: \{{ default_ds_min_size }}
+          max-pool-size: {{ default_ds_max_size }}
+          min-pool-size: {{ default_ds_min_size }}
           connection-url: "jdbc:{% if ansible_distribution_major_version == 9 %}mariadb{% else %}postgresql{% endif %}://localhost/default_ds"
-          driver-name: \{% if ansible_distribution_major_version == 9 %}mariadb{% else %}postgresql{% endif %}
+          driver-name: {% if ansible_distribution_major_version == 9 %}mariadb{% else %}postgresql{% endif %}
 ----
 
 == Conclusion

--- a/content/posts/2024-10-10-jakarta-data.adoc
+++ b/content/posts/2024-10-10-jakarta-data.adoc
@@ -32,7 +32,7 @@ Following is an example repository:
 [source,java]
 ----
 @Repository
-interface Publishing \{
+interface Publishing {
     @Find
     Book book(String isbn);
 

--- a/content/posts/2024-11-04-WildFly-playing-with-generative-ai.adoc
+++ b/content/posts/2024-11-04-WildFly-playing-with-generative-ai.adoc
@@ -271,7 +271,7 @@ The code itself is quite straightforward:
 ----
 @ServerEndpoint(value = "/websocket/chatbot",
         configurator = org.wildfly.ai.websocket.CustomConfigurator.class)
-public class RagChatBot \{
+public class RagChatBot {
     @Inject
     @Named(value = "ollama")
     ChatLanguageModel chatModel;
@@ -289,7 +289,7 @@ public class RagChatBot \{
             + "{{contents}}";
 
   @OnMessage
-  public String sayHello(String question, Session session) throws IOException \{
+  public String sayHello(String question, Session session) throws IOException {
         ChatMemory chatMemory = MessageWindowChatMemory.builder().id(session.getUserProperties().get("httpSessionId")).maxMessages(3).build();
         ConversationalRetrievalChain chain = ConversationalRetrievalChain.builder()
                 .chatLanguageModel(chatModel)
@@ -300,7 +300,7 @@ public class RagChatBot \{
         return result;
     }
 
-    private RetrievalAugmentor createBasicRag() \{
+    private RetrievalAugmentor createBasicRag() {
         return DefaultRetrievalAugmentor.builder()
                 .contentRetriever(retriever)
                 .contentInjector(DefaultContentInjector.builder()
@@ -352,4 +352,3 @@ If you look at the code you can easily tweak it to try several scenarios like us
 Also you can try https://openai.com/[OpenAI, window=_blank] or https://groq.com[Groq, window=_blank] instead of Ollama.
 
 All the source code of the feature pack is available on https://github.com/wildfly-extras/wildfly-ai-feature-pack[Github, window=_blank] and can be improved by extending the components that may be of use.
-

--- a/content/posts/2024-11-14-using-maven-wildfly-plugin-with-postgresql-ds.adoc
+++ b/content/posts/2024-11-14-using-maven-wildfly-plugin-with-postgresql-ds.adoc
@@ -201,9 +201,9 @@ And then we can check the configured datasource in the server:
 [standalone@localhost:9990 /] /subsystem=datasources:read-resource
 {
     "outcome" => "success",
-    "result" => \{
-        "data-source" => \{"PostgreSQLDS" => undefined},
-        "jdbc-driver" => \{"postgresql" => undefined},
+    "result" => {
+        "data-source" => {"PostgreSQLDS" => undefined},
+        "jdbc-driver" => {"postgresql" => undefined},
         "xa-data-source" => undefined
     }
 }
@@ -216,15 +216,15 @@ You can see the `PostgreSQLDS` is now the configured datasource. Then we can che
 [standalone@localhost:9990 /] /subsystem=batch-jberet:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "restart-jobs-on-resume" => true,
         "security-domain" => "ApplicationDomain",
         "default-job-repository" => "batch_db",
         "default-thread-pool" => "batch",
-        "in-memory-job-repository" => \{"in-memory" => undefined},
-        "jdbc-job-repository" => \{"batch_db" => undefined},
+        "in-memory-job-repository" => {"in-memory" => undefined},
+        "jdbc-job-repository" => {"batch_db" => undefined},
         "thread-factory" => undefined,
-        "thread-pool" => \{"batch" => undefined}
+        "thread-pool" => {"batch" => undefined}
     }
 }
 ----
@@ -236,7 +236,7 @@ As the output shown above, the `default-job-repository` is configured to use the
 [standalone@localhost:9990 /] /subsystem=batch-jberet/jdbc-job-repository=batch_db:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "data-source" => "PostgreSQLDS",
         "execution-records-limit" => undefined
     }
@@ -267,7 +267,7 @@ If you check the configuration by running the example with the `-Ppostgres` prof
 [standalone@localhost:9990 /] /subsystem=batch-jberet/jdbc-job-repository=batch_db:read-resource
 {
     "outcome" => "success",
-    "result" => \{
+    "result" => {
         "data-source" => "batch_db",
         "execution-records-limit" => undefined
     }

--- a/content/posts/2025-01-27-testing-on-docker-with-cube.adoc
+++ b/content/posts/2025-01-27-testing-on-docker-with-cube.adoc
@@ -287,7 +287,7 @@ import java.net.URI;
  * Run integration tests with Arquillian to be able to test CDI beans
  */
 @RunWith(Arquillian.class)
-public class GettingStartedDockerIT \{
+public class GettingStartedDockerIT {
 
     @HostIp
     private String wildflyIp;
@@ -296,8 +296,8 @@ public class GettingStartedDockerIT \{
     int wildflyPort;
 
     @Test
-    public void testHelloEndpoint() \{
-        try (Client client = ClientBuilder.newClient()) \{
+    public void testHelloEndpoint() {
+        try (Client client = ClientBuilder.newClient()) {
             final String name = "World";
             Response response = client
                     .target(URI.create("http://" + wildflyIp + ":" + wildflyPort + "/"))

--- a/content/posts/2025-02-12-Glowing-with-AI.adoc
+++ b/content/posts/2025-02-12-Glowing-with-AI.adoc
@@ -158,7 +158,7 @@ Here is where the magic is happening :
 ----
 @ServerEndpoint(value = "/chatbot",
         configurator = CustomConfigurator.class)
-public class ChatBotWebSocketEndpoint \{
+public class ChatBotWebSocketEndpoint {
 
     private static final Logger logger = Logger.getLogger(ChatBotWebSocketEndpoint.class.getName());
 
@@ -182,7 +182,7 @@ public class ChatBotWebSocketEndpoint \{
 
     // It starts a Thread that notifies all sessions each second
     @PostConstruct
-    public void init() \{
+    public void init() {
     ...
     }
 ...

--- a/content/posts/2025-02-12-wildfly-domain-usage.adoc
+++ b/content/posts/2025-02-12-wildfly-domain-usage.adoc
@@ -151,10 +151,10 @@ In addition, there are several interface properties defined in the `host.xml` fi
 ----
 <interfaces>
     <interface name="management">
-        <inet-address value="$\{jboss.bind.address.management:127.0.0.1}"/>
+        <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
     </interface>
     <interface name="public">
-        <inet-address value="$\{jboss.bind.address:127.0.0.1}"/>
+        <inet-address value="${jboss.bind.address:127.0.0.1}"/>
     </interface>
 </interfaces>
 ----
@@ -256,7 +256,7 @@ You are disconnected at the moment. Type 'connect' to connect to the server or '
     "outcome" => "success",
     "result" => undefined,
     "server-groups" => undefined,
-    "response-headers" => \{"process-state" => "reload-required"}
+    "response-headers" => {"process-state" => "reload-required"}
 }
 ----
 
@@ -282,7 +282,7 @@ So I need to define this `authentication-context` in the `elytron` subsystem. Th
                 <credential-reference clear-text="123"/>
             </authentication-configuration>
             <authentication-context name="myCtx">
-                <match-rule match-host="$\{jboss.domain.primary.address}" authentication-configuration="myConfig"/>
+                <match-rule match-host="${jboss.domain.primary.address}" authentication-configuration="myConfig"/>
             </authentication-context>
         </authentication-client>
         ...
@@ -295,13 +295,13 @@ Here is the equivalent CLI command to do the configuration:
 
 [source,bash]
 ----
-[domain@embedded /] /host=secondary/subsystem=elytron/authentication-configuration=myConfig:add(sasl-mechanism-selector=DIGEST-MD5, authentication-name=admin, realm=ManagementRealm, credential-reference=\{clear-text="123"})
+[domain@embedded /] /host=secondary/subsystem=elytron/authentication-configuration=myConfig:add(sasl-mechanism-selector=DIGEST-MD5, authentication-name=admin, realm=ManagementRealm, credential-reference={clear-text="123"})
 {"outcome" => "success"}
 ----
 
 [source,bash]
 ----
-[domain@embedded /] /host=secondary/subsystem=elytron/authentication-context=myCtx:add(match-rules=[{match-host="$\{jboss.domain.primary.address}", authentication-configuration=myConfig}])
+[domain@embedded /] /host=secondary/subsystem=elytron/authentication-context=myCtx:add(match-rules=[{match-host="${jboss.domain.primary.address}", authentication-configuration=myConfig}])
 {"outcome" => "success"}
 ----
 
@@ -314,8 +314,8 @@ Then I need to add modify configuration of the `domain-controller`:
 <domain-controller>
     <remote authentication-context="myCtx">
         <discovery-options>
-            <static-discovery name="primary" protocol="$\{jboss.domain.primary.protocol:remote+http}"
-                              host="$\{jboss.domain.primary.address}" port="$\{jboss.domain.primary.port:9990}"/>
+            <static-discovery name="primary" protocol="${jboss.domain.primary.protocol:remote+http}"
+                              host="${jboss.domain.primary.address}" port="${jboss.domain.primary.port:9990}"/>
         </discovery-options>
     </remote>
 </domain-controller>
@@ -330,7 +330,7 @@ As the configuration is shown above, I defined the `authentication-context` to b
     "outcome" => "success",
     "result" => undefined,
     "server-groups" => undefined,
-    "response-headers" => \{"process-state" => "reload-required"}
+    "response-headers" => {"process-state" => "reload-required"}
 }
 ----
 

--- a/content/posts/2025-03-06-testing-on-k8s-with-cube.adoc
+++ b/content/posts/2025-03-06-testing-on-k8s-with-cube.adoc
@@ -494,7 +494,7 @@ import static org.junit.Assert.assertNotNull;
  * Run integration tests on Kubernetes with Arquillian Cube!
  */
 @RunWith(Arquillian.class)
-public class GettingStartedKubernetesIT \{
+public class GettingStartedKubernetesIT {
 
     @Named("my-jaxrs-app-service")
     @ArquillianResource
@@ -506,7 +506,7 @@ public class GettingStartedKubernetesIT \{
     private URL url;
 
     @Test
-    public void shouldFindServiceInstance() \{
+    public void shouldFindServiceInstance() {
         assertNotNull(myJaxrsAppService);
         assertNotNull(myJaxrsAppService.getSpec());
         assertNotNull(myJaxrsAppService.getSpec().getPorts());
@@ -514,9 +514,9 @@ public class GettingStartedKubernetesIT \{
     }
 
     @Test
-    public void shouldShowHelloWorld() throws URISyntaxException \{
+    public void shouldShowHelloWorld() throws URISyntaxException {
         assertNotNull(url);
-        try (Client client = ClientBuilder.newClient()) \{
+        try (Client client = ClientBuilder.newClient()) {
             final String name = "World";
             Response response = client
                     .target(url.toURI())

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <skipITs>true</skipITs>
 
         <version.compiler-plugin>3.14.0</version.compiler-plugin>
-        <version.quarkus-roq>1.6.3</version.quarkus-roq>
-        <version.quarkus.platform>3.24.1</version.quarkus.platform>
+        <version.quarkus-roq>1.8.1</version.quarkus-roq>
+        <version.quarkus.platform>3.25.0</version.quarkus.platform>
         <version.surefire-plugin>3.5.2</version.surefire-plugin>
     </properties>
 

--- a/src/main/java/org/wildfly/site/Extensions.java
+++ b/src/main/java/org/wildfly/site/Extensions.java
@@ -1,15 +1,13 @@
 package org.wildfly.site;
 
+import io.quarkiverse.qute.web.markdown.runtime.MdConverter;
+import io.quarkus.arc.Arc;
+import io.quarkus.qute.TemplateExtension;
+
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
-import io.quarkiverse.qute.web.markdown.runtime.MdConverter;
-import io.quarkiverse.roq.frontmatter.runtime.model.DocumentPage;
-import io.quarkiverse.roq.plugin.asciidoctorj.runtime.AsciidoctorJConverter;
-import io.quarkus.arc.Arc;
-import io.quarkus.qute.TemplateExtension;
 
 @TemplateExtension
 public class Extensions {
@@ -28,12 +26,6 @@ public class Extensions {
 
     public static String join(List<?> list, String separator) {
         return String.join(separator, list.stream().map(Object::toString).toList());
-    }
-
-    public static String asciidoc(String rawText) {
-        AsciidoctorJConverter converter = Arc.container().beanInstanceSupplier(AsciidoctorJConverter.class).get().get();
-
-        return converter.apply(rawText.replaceAll("\\{[#/]asciidoc}", ""));
     }
 
     public static String markdown(String rawText) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,5 @@ site.collections.posts=true
 site.collections.events=true
 site.collections.docs.layout=conference
 site.collections.docs.future=true
+
+quarkus.asciidoc.attributes.imagesdir=/assets/img/news/

--- a/src/main/resources/web/app/global.scss
+++ b/src/main/resources/web/app/global.scss
@@ -170,7 +170,6 @@ code {
   overflow: auto;
   padding: 0 2px;
   border-radius: 4px;
-  max-width:1000px
 }
 
 
@@ -266,10 +265,6 @@ table {
   .content {
     padding: 0;
   }
-}
-
-.listingblock {
-    max-width: 1000px;
 }
 
 .paginator-btns a {

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -17,13 +17,15 @@
   {! <link rel="stylesheet" href="{site.url('/assets/css/main.css')}" /> !}
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-40221748-1"></script>
+  {|
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag()\{dataLayer.push(arguments);}
+    function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
     gtag('config', 'UA-40221748-1');
   </script>
+  |}
 
   {#if page.data.containsKey('external_link')}
   <meta http-equiv="refresh" content="0; {page.data.external_link}">

--- a/templates/layouts/events.html
+++ b/templates/layouts/events.html
@@ -2,7 +2,6 @@
 layout: base
 ---
 <div class="grid-wrapper events">
-  {|
   <div class="grid__item width-10-12 width-12-12-m">
     <h1>Wild<strong>Fly</strong> Events</h1>
     <h2 class="page-subtitle">
@@ -22,6 +21,7 @@ layout: base
         </tr></tbody>
       </table>
     </div>
+    {|
     <script type="text/javascript">
       const options = {
         src: 'wildflyorg%40gmail.com',
@@ -35,8 +35,8 @@ layout: base
       const iframe = `<iframe src="${url}" style="${style}" ${attributes}></iframe>`;
       document.getElementById('wildfly-org-calendar-container').innerHTML = iframe;
     </script>
+    |}
   </div>
-  |}
 
   <div class="grid__item events-toc">
     <h3>On this page</h3>
@@ -118,4 +118,3 @@ layout: base
     {/for}
   </div>
 </div>
-

--- a/templates/layouts/guide.html
+++ b/templates/layouts/guide.html
@@ -1,6 +1,6 @@
 ---
 layout: base
-link: /guides/:slug
+link: /:path
 ---
 
 <div class="grid-wrapper guide">

--- a/templates/partials/guides/prerequisites.adoc
+++ b/templates/partials/guides/prerequisites.adoc
@@ -1,4 +1,3 @@
-{|
 [[prerequisites]]
 == Prerequisites
 
@@ -7,4 +6,3 @@ To complete this guide, you need:
 * Roughly {prerequisites-time} minutes
 * JDK {jdk-minimal-version} installed with `JAVA_HOME` configured appropriately
 * Apache Maven {maven-version}
-|}

--- a/templates/partials/guides/proc-log-into-openshift-cluster.adoc
+++ b/templates/partials/guides/proc-log-into-openshift-cluster.adoc
@@ -1,4 +1,3 @@
-{|
 == Log Into the OpenShift Cluster
 
 Before we can deploy our application, we need to log in to an OpenShift cluster. You can log in via the https://docs.openshift.com/container-platform/{ocp-version}/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI]:
@@ -24,4 +23,3 @@ If you don't already have a project created, you can create one using:
 oc new-project myProjectName
 ----
 
-|}


### PR DESCRIPTION
With Roq 1.7.0, asciidoc files gain cleaner support (i.e., they are no longer processed as Qute templates by default), so our handling of asciidoc markup can be cleaned up and simplified. Additionally, adoc includes are now properly handled, so we can revert the includes back to that format. This update will reduce the burden on page/post devs in general, and get closer to how things were with the jekyll build (still without the ruby pain :).

- Bump Roq version to pull in bug fixes and feature enhancements
- Remove adoc escapes since Roq now handles this more cleanly 
- Use standard adoc includes instead of Qute includes 
- Set global imagesdir property to fix broken images