### PR TITLE
Fix double-escaped release excerpts

### DIFF
--- a/templates/layouts/releases.html
+++ b/templates/layouts/releases.html
@@ -30,7 +30,7 @@ layout: base
           {#if post.data.containsKey('synopsis')}
             <p>{post.data.synopsis}</p>
           {#else}
-            <p>{site.pageContent(post).stripHtml.wordLimit(75)}</p>
+            <p>{site.pageContent(post).stripHtml.wordLimit(75).raw}</p>
           {/if}
         </div>
         <div class="grid__item width-12-12">
@@ -46,5 +46,3 @@ layout: base
 
   <div class="grid__item width-2-12"></div>
 </div>
-
-


### PR DESCRIPTION
## Summary
- fix the releases page excerpt rendering to avoid double-escaped HTML entities
- align the releases excerpt rendering with the existing news excerpt handling

e.g., 
<img width="1267" height="319" alt="image" src="https://github.com/user-attachments/assets/ceede86e-f1d0-4367-8d0c-7a6a70b5599a" />

## Testing
- mvn quarkus:dev
- verified the rendered /releases page locally