### PR TITLE
[#860] Include category tags in RSS feed

### DIFF
--- a/templates/fm/rss.html
+++ b/templates/fm/rss.html
@@ -1,0 +1,40 @@
+{@java.lang.String collectionName}
+{@java.lang.Integer contentLimit}
+{@io.quarkiverse.roq.frontmatter.runtime.model.Site site}
+{@io.quarkiverse.roq.frontmatter.runtime.model.NormalPage page}
+{#let name=(collectionName ?: 'posts') cl=contentLimit.or(-1)}
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <title><![CDATA[ {site.title} ]]></title>
+    <description><![CDATA[ {site.description} ]]></description>
+    <link>{site.url.absolute}</link>
+    <atom:link href="{site.url('rss.xml').absolute}" rel="self" type="application/rss+xml"/>
+    <generator>Quarkus Roq</generator>
+    {#if site.collections.get(name)}
+    <lastBuildDate>{#if site.collections.get(name).size > 0}{site.collections.get(name).get(0).date.rfc822}{/if}</lastBuildDate>
+    {#for post in site.collections.get(name)}
+      <item>
+        <title><![CDATA[{post.title}]]></title>
+        <link>{post.url.absolute}</link>
+        <guid isPermaLink="false">{post.url.absolute}</guid>
+        <pubDate>{post.date.rfc822}</pubDate>
+        {#if post.data.tags}
+        {#for tag in post.data.tags.asStrings}
+        <category>{tag}</category>
+        {/for}
+        {/if}
+        <description><![CDATA[{post.description}]]></description>
+        {#if cl >= 0}
+        {#if cl == 0}
+        <content:encoded><![CDATA[{post.content}<div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {#else}
+        <content:encoded><![CDATA[<p>{post.contentAbstract(contentLimit)}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {/if}
+        {#else}
+        <content:encoded><![CDATA[<p>{post.description}</p><div style="margin-top: 50px; font-style: italic;"><strong><a href="{post.url.absolute}">Keep reading</a>.</strong></div><br /> <br />]]></content:encoded>
+        {/if}
+      </item>
+    {/for}
+    {/if}
+  </channel>
+</rss>


### PR DESCRIPTION
Override the default ROQ RSS template to include category elements for each post tags, allowing RSS readers to filter feed content.

Source template file is https://raw.githubusercontent.com/quarkiverse/quarkus-roq/refs/heads/main/roq-frontmatter/runtime/src/main/resources/templates/fm/rss.html

<img width="1778" height="473" alt="image" src="https://github.com/user-attachments/assets/98166973-6598-49f6-a681-fd6538d4e16b" />
