### PR TITLE
[WFLY-20972] Replaced "Home" with "Back to Guides" in the guides

### DIFF
--- a/templates/layouts/getstarted.html
+++ b/templates/layouts/getstarted.html
@@ -9,6 +9,6 @@ layout: base
         </div>
     </div>
     <div class="grid__item width-12-12 width-12-12-mobile">
-        <div>&lt; <a href="{site.url}">Home</a></div>
+        <div>&lt; <a href="{site.url('guides')}">Back to Guides</a></div>
     </div>
 </div>


### PR DESCRIPTION
JIRA Issue: [WFLY-20972](https://redhat.atlassian.net/browse/WFLY-20972)

Description: As highlighted in the related [github issue](https://github.com/wildfly/wildfly.org/issues/800), some guides contained inconsistent navigation links at the bottom. Some pointing to the home page, while others pointing to the `/guides` page.

This change standardises the behaviour by updating all links to consistently direct users to the `/guides` page, providing a more intuitive navigation experience. 
