### PR TITLE
[Issue_926] Align WF 41 release announcement TCK result links with th…

### DIFF
--- a/content/posts/2026-07-16-WildFly41Released.adoc
+++ b/content/posts/2026-07-16-WildFly41Released.adoc
@@ -95,14 +95,14 @@ Evidence demonstrating our compatibility is available in the link:https://github
 |=======================================================================
 |Specification |Compatibility Evidence
 .2+.<| EE 10 Full Platform
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-full-platform-jdk17.adoc#tck-results[SE 17, window=_blank]
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-full-platform-jdk21.adoc#tck-results[SE 21, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-full-platform-jdk17.adoc#tck-results[SE 17, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-full-platform-jdk21.adoc#tck-results[SE 21, window=_blank]
 .2+.<|  EE 10 Web Profile
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-web-profile-jdk17.adoc#tck-results[SE 17, window=_blank]
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-web-profile-jdk21.adoc#tck-results[SE 21, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-web-profile-jdk17.adoc#tck-results[SE 17, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-web-profile-jdk21.adoc#tck-results[SE 21, window=_blank]
 .2+.<| EE 10 Core Profile
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-core-jdk17.adoc#jakarta-core-profile-1001-tck-java-se-17-results[SE 17, window=_blank]
-| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_41.0.0.Final/jakarta-core-jdk21.adoc#jakarta-core-profile-1001-tck-java-se-21-results[SE 21, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-core-jdk17.adoc#jakarta-core-profile-1001-tck-java-se-17-results[SE 17, window=_blank]
+| link:https://github.com/wildfly/certifications/blob/EE10/WildFly_EE_10_41.0.0.Final/jakarta-core-jdk21.adoc#jakarta-core-profile-1001-tck-java-se-21-results[SE 21, window=_blank]
 |=======================================================================
 
 


### PR DESCRIPTION
…e corrected URLs in the certifications repo

Resolves #926 

**IMPORTANT**: This _**should not**_ be merged until https://github.com/wildfly/certifications/pull/131 is merged. It **_should_** be merged immediately after that PR is merged.